### PR TITLE
refactor: Share evaluation semantics across runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ end
 # Initialize evaluation structure
 mix tribunal.init
 
-# Run evaluations (default: always exit 0, just report)
+# Run evaluations (quality failures are report-only by default)
 mix tribunal.eval
 
 # Set pass threshold (fail if pass rate < 80%)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -118,7 +118,7 @@ The next work is organized around one rule: Mix and ExUnit share evaluation sema
 
 `mix tribunal.eval` stays the batch interface. Providers continue receiving the full `Tribunal.TestCase`, while the Mix task owns dataset execution, concurrency, aggregation, quality gates, reports, and exit codes.
 
-### Phase 1: trustworthy shared evaluation
+### Current: trustworthy shared evaluation
 
 - Route both `tribunal_eval` and `mix tribunal.eval` through `Tribunal.Evaluator`.
 - Preserve the existing public APIs and provider contracts.
@@ -127,13 +127,13 @@ The next work is organized around one rule: Mix and ExUnit share evaluation sema
 - Apply `tribunal_eval` defaults with case-specific options taking precedence.
 - Fix the remaining unsafe dataset and CLI boundaries before adding more features.
 
-### Phase 2: structured inputs
+### Next: structured inputs
 
 Tracking [issue #32](https://github.com/georgeguimaraes/tribunal/issues/32). Dataset input should accept structured JSON-compatible data, usually a map of variables. The application provider owns prompt rendering because the prompt is application code.
 
 Tribunal will not add its own template language. Existing string inputs remain valid, and the two provider contracts stay unchanged: ExUnit receives `test_case.input`, while the Mix provider receives the full test case.
 
-### Phase 3: repeated runs and batch gates
+### Later: repeated runs and batch gates
 
 Tracking [issue #35](https://github.com/georgeguimaraes/tribunal/issues/35). Repeated attempts and their reduction belong in the shared single-case evaluation model. Dataset-wide and per-group thresholds belong in `mix tribunal.eval`, where Tribunal owns the batch.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,182 +108,36 @@ So "porting promptfoo's catalog" means three different kinds of work:
 - GitHub Action runs `mix ngen.red_team_eval --output report.json` on cron (nightly?).
 - Surface failures as PR comments or just a Slack ping.
 
-## Dataset template variables (issue #32)
+## Evaluation architecture
 
-Tracking [issue #32](https://github.com/georgeguimaraes/tribunal/issues/32). Matt McCoy flagged that large prompt templates with per-row interpolation slots don't fit the current dataset shape. Putting the rendered prompt into each row's `input:` duplicates the template across every row; a custom provider that ignores `input` and rebuilds the prompt works but ducks the design intent. Separate from the red-team work but lives in this doc since it's the only roadmap.
+The next work is organized around one rule: Mix and ExUnit share evaluation semantics, while each keeps its native execution model.
 
-### What the feature does
+`Tribunal.Evaluator` owns single-case truth. It evaluates an output against assertions, preserves repeated assertions, applies defaults, and returns a passed or failed case result. Missing output, missing assertions, assertion errors, and unexpected assertion responses fail closed.
 
-User keeps the prompt template in code (where it already lives), uses `{{var}}` placeholders, and the dataset YAML carries only per-row variables. Example:
+`tribunal_eval` stays native to ExUnit. One dataset row generates one ExUnit test, providers continue receiving the input string, and ExUnit owns test scheduling, filtering, timeouts, and failure presentation.
 
-```elixir
-@template """
-You are a customer service agent for Acme.
-Order ID: {{order_id}}
-Customer says: {{message}}
-Decline refunds older than 30 days.
-"""
-```
+`mix tribunal.eval` stays the batch interface. Providers continue receiving the full `Tribunal.TestCase`, while the Mix task owns dataset execution, concurrency, aggregation, quality gates, reports, and exit codes.
 
-```yaml
-- vars:
-    order_id: "12345"
-    message: "I want a refund for an order from 6 months ago"
-  expected:
-    refusal: {}
-    contains: ["30 days"]
-```
+### Phase 1: trustworthy shared evaluation
 
-```elixir
-tribunal_eval "test/evals/datasets/support.yaml",
-  template: Acme.SupportPrompt.template(),
-  provider: {Acme.SupportLLM, :chat}
-```
+- Route both `tribunal_eval` and `mix tribunal.eval` through `Tribunal.Evaluator`.
+- Preserve the existing public APIs and provider contracts.
+- Fail closed on missing outputs and assertion errors.
+- Preserve repeated assertion results instead of losing them in a map.
+- Apply `tribunal_eval` defaults with case-specific options taking precedence.
+- Fix the remaining unsafe dataset and CLI boundaries before adding more features.
 
-```bash
-mix tribunal.eval support.yaml \
-  --template-file priv/prompts/support.txt \
-  --provider Acme.SupportLLM.chat
-```
+### Phase 2: structured inputs
 
-Tribunal renders the template with each row's `vars` to produce `test_case.input`, then the provider runs as today and assertions work unchanged.
+Tracking [issue #32](https://github.com/georgeguimaraes/tribunal/issues/32). Dataset input should accept structured JSON-compatible data, usually a map of variables. The application provider owns prompt rendering because the prompt is application code.
 
-### Design choices
+Tribunal will not add its own template language. Existing string inputs remain valid, and the two provider contracts stay unchanged: ExUnit receives `test_case.input`, while the Mix provider receives the full test case.
 
-- Syntax: `{{var}}` Mustache-style. No clash with Elixir `#{}`, no EEx dep, no escaping headaches.
-- Template lives in code, not YAML. Multi-line prompts don't fit cleanly into YAML rows, and code is where users already organise prompts.
-- New dedicated `:vars` field on `Tribunal.TestCase`, not stuffed under `metadata`. Discoverable, validates better.
-- Both `input` and `vars` on the same row → error (ambiguous about what reaches the LLM).
-- Template references a missing var → error early with a clear message (`"template references {{order_id}} but vars has [:message] only"`).
-- Render target is `input`. Existing assertions that read `test_case.input` (jailbreak query context, etc.) keep working.
+### Phase 3: repeated runs and batch gates
 
-### Implementation footprint
+Tracking [issue #35](https://github.com/georgeguimaraes/tribunal/issues/35). Repeated attempts and their reduction belong in the shared single-case evaluation model. Dataset-wide and per-group thresholds belong in `mix tribunal.eval`, where Tribunal owns the batch.
 
-- New `Tribunal.Template` module — `render(template, vars) :: {:ok, str} | {:error, {:missing_vars, [...]}}`. Regex substitution, no template engine dep, ~30 lines.
-- `Tribunal.TestCase` gets a `:vars` field.
-- `Tribunal.Dataset` threads `vars` through; renders when the caller passes a template.
-- `Tribunal.EvalCase.tribunal_eval/2` accepts `:template`.
-- `Mix.Tasks.Tribunal.Eval` accepts `--template-file` and `--template`.
-- Tests: render correctness, missing-var error, both-`input`-and-`vars` rejection.
-
-Roughly 1-2 days including docs update in `guides/datasets.md`.
-
-### Stopgap for the open issue
-
-Until this ships, the workaround is: put per-row vars under `metadata:` in the YAML and write a provider that reads `test_case.metadata` to render the template. `mix tribunal.eval --provider Module.fun` already passes the full `TestCase` through, so no replacement runner is needed. Worth posting this on issue #32 alongside a link to the planned feature so Matt's follow-up doesn't sit unanswered.
-
-## Repeated sampling and thresholds (issue #35)
-
-Tracking [issue #35](https://github.com/georgeguimaraes/tribunal/issues/35). Matt McCoy flagged that code-based eval tests are all-or-nothing pass, which is flaky when the LLM under test is nondeterministic. The fix is repeated sampling: run each case N times and decide pass/fail statistically instead of on a single roll. This is also the top gap surfaced by the Python-ecosystem survey (DeepEval/Inspect/promptfoo all do repeated runs, pass@k, and confidence intervals), so it does double duty.
-
-### The mental model: two axes
-
-"Repeated sampling + thresholds" is two mechanisms that compose. Keeping them separate is what keeps the config clean.
-
-**Axis 1 — the per-case rule (within-case).** Run one case K times through the provider, then collapse the K runs to a single case verdict via a rule:
-
-- `all` (pass^k) — passes only if every run passed. Reliability. The right default for safety gates (`refute_jailbreak`): one leak in five is a fail.
-- `any` (pass@k) — passes if any run passed. Capability ("can it ever get this right"), the classic code-gen/agent metric.
-- `majority` — passes if more than half passed. Robust to a flaky judge without demanding perfection.
-- `rate:P` — passes if the fraction passing ≥ P (e.g. at least 80% of 10 runs).
-
-**Axis 2 — the suite statistic (across-case).** Once each case has a verdict, summarize the dataset with a confidence interval instead of a bare point estimate, and gate on that. Today `aggregate_results` computes `pass_rate = passed/total` and the gate is `pass_rate >= threshold` (`lib/mix/tasks/tribunal.ex:124-133`). A Wilson score interval turns 42/50 into "84% (95% CI 72–92%)", and gating on the interval's lower bound stops us shipping on a lucky run.
-
-They compose: the repeats from Axis 1 are also what give Axis 2 enough samples for a meaningful interval.
-
-### How it slots into the code
-
-The insertion point is small and localized. `run_case/3` (`lib/mix/tasks/tribunal.ex:188`) calls the provider once and evaluates assertions once. Repeated sampling wraps exactly that:
-
-```
-run_case  →  run_case_repeated(test_case, assertions, provider, repeat, pass_rule)
-              ├─ run provider + evaluate_all K times
-              ├─ collect K per-run result maps
-              ├─ per assertion: count passes across runs (for flakiness reporting)
-              └─ collapse to one case verdict via pass_rule
-```
-
-Everything downstream (`aggregate_results`, thresholds, reporters) keeps working because a case still ends up `:passed`/`:failed`, just decided over K runs. `aggregate_results` gains the Wilson CI computed from the case verdicts. Concurrency already exists via `Task.async_stream` (`:172`); repeats change the work list from `cases` to `cases × K`, so `--concurrency` parallelizes across repeats with no new machinery.
-
-Statistical note on "n": collapsing each case to one verdict gives a suite CI with n = number of cases (each case one Bernoulli trial over the dataset) — that's the CI to gate CI/CD on. Separately, the K runs of a single case give a per-case CI (n = K) that measures how flaky that case is. Different questions; surface both — suite CI in the summary, per-case rate on failures.
-
-### Config and DX — mix task
-
-Four new flags. `--repeat` defaults to 1, so existing behavior and cost are untouched.
-
-```bash
-mix tribunal.eval --repeat 5                                   # each case 5×, pass only if all 5 pass
-mix tribunal.eval --repeat 5 --pass-rule majority --threshold 0.8
-mix tribunal.eval --repeat 10 --threshold 0.8 --threshold-ci  # gate on Wilson lower bound
-mix tribunal.eval --repeat 10 --pass-rule any                 # pass@k capability metric
-```
-
-- `--repeat N` — samples per case (default 1).
-- `--pass-rule all|any|majority|rate:P` — per-case rule (default `all`).
-- `--threshold P` — existing suite gate.
-- `--threshold-ci` — modifier: gate `--threshold` on the Wilson lower bound instead of the point estimate.
-
-`--strict` still means "no case may fail" and composes with the rule (strict + `all` = every case passes every run, strongest gate).
-
-Output is where it earns its keep — failures split flaky from consistent:
-
-```
-Summary
-  Total:     50 cases × 5 runs
-  Passed:    42 (84%, 95% CI 72–92%)
-  Pass rule: all (5/5 must pass)
-
-Failed Cases
-  1. "return policy for electronics?"
-     └─ faithful: failed 3/5 runs (40% pass) — FLAKY
-  2. "can I return opened software?"
-     └─ relevant: failed 5/5 runs (0% pass) — CONSISTENT
-```
-
-The flaky-vs-consistent split is the single most useful thing this produces: "the model can't do this" vs "it does this 2 times in 5" need different fixes.
-
-### Config and DX — ExUnit
-
-Repeat only makes sense where tribunal owns the provider call, so it lives on the dataset macro (`lib/tribunal/eval_case.ex:52`), which already controls invocation:
-
-```elixir
-tribunal_eval "test/evals/datasets/questions.json",
-  provider: {MyApp.RAG, :query},
-  repeat: 5,
-  pass_rule: :majority
-```
-
-Each generated test runs provider + assertions K times and flunks per the rule, with a message like `faithful: failed 3/5 runs`.
-
-Inline assertions (`assert_faithful response, ...`) receive an already-computed string, so there's nothing to resample — don't bolt repeat onto them (misleading). Offer an explicit generator form instead:
-
-```elixir
-assert_consistently 5, fn -> MyApp.RAG.query(q) end,
-  faithful: [context: @docs],
-  pass_rule: :all
-```
-
-Keeps the honest distinction: `assert_faithful` grades one output; `assert_consistently` grades a generator over K samples.
-
-### Statistics
-
-- Default to **Wilson score intervals**: no dependency, well understood, behaves at small n and near 0/1 where the normal approximation breaks.
-- The "Don't Pass@k" Bayesian posterior (Beta over the pass rate) from the survey (arxiv 2510.04265) is a legitimate upgrade — reads more naturally than a frequentist CI — but ship it later as `--stat bayesian`, not the v1 default.
-- If someone samples more than k, the unbiased pass@k estimator (Codex paper: `1 - C(n-c,k)/C(n,k)`) is the rigorous form; for the common `repeat == k` case it collapses to "any of the k passed".
-
-### Cost and gotchas
-
-- Repeats multiply provider + judge calls by K. Default `--repeat` to 1 and print the multiplier plainly (`50 cases × 5 runs = 250 invocations`).
-- No output caching by default — the point is fresh nondeterministic samples.
-- Per-row `metadata.repeat` override is a cheap nice-to-have so a known-flaky case can ask for more samples while the rest stay low.
-
-### Phasing
-
-1. **v1** — `--repeat` + `--pass-rule` in the mix task, `repeat:`/`pass_rule:` on `tribunal_eval`, and the flaky/consistent reporting in `Reporter.Console`. Closes #35 on its own. The reduction lives in a small `Tribunal.Sampling` (pass_rule over K runs + per-assertion pass counts).
-2. **v2** — Wilson CI in `aggregate_results` + `--threshold-ci`, CI shown in the summary and JSON/HTML reporters.
-3. **v3** — `assert_consistently` for in-test repeats, `metadata.repeat` per-row override, and `--stat bayesian`.
-
-Each phase is independently shippable. v1 is roughly 1-2 days including reporter updates and tests (pass_rule reduction, flaky detection, threshold composition).
+ExUnit continues to report one test result per dataset row. A repeated case can be represented as one ExUnit test, but suite-wide percentage gates will not be hidden inside independently scheduled ExUnit tests. Use `mix tribunal.eval` when the acceptance decision depends on aggregate statistics.
 
 ## Open decisions still on the table
 

--- a/guides/assertions.md
+++ b/guides/assertions.md
@@ -352,7 +352,7 @@ All LLM assertions accept:
 
 ```elixir
 Assertions.evaluate(:faithful, test_case,
-  model: "anthropic:claude-3-5-sonnet-latest",  # default: claude-3-5-haiku-latest
+  model: "anthropic:claude-sonnet-4-6",  # default: claude-haiku-4-5-20251001
   threshold: 0.9,                                # default: 0.8
   temperature: 0.0,
   max_tokens: 500

--- a/guides/datasets.md
+++ b/guides/datasets.md
@@ -89,7 +89,7 @@ Multiple values:
 
 With options:
 ```json
-{"faithful": {"threshold": 0.9, "model": "anthropic:claude-3-5-sonnet-latest"}}
+{"faithful": {"threshold": 0.9, "model": "anthropic:claude-sonnet-4-6"}}
 ```
 
 No options:
@@ -165,7 +165,7 @@ tribunal_eval "test/evals/datasets/questions.json",
   provider: {MyApp.RAG, :query},
   defaults: [
     threshold: 0.9,
-    model: "anthropic:claude-3-5-sonnet-latest"
+    model: "anthropic:claude-sonnet-4-6"
   ]
 ```
 

--- a/guides/evaluation-modes.md
+++ b/guides/evaluation-modes.md
@@ -198,7 +198,7 @@ tribunal_eval "test/evals/datasets/questions.json",
 mix tribunal.eval --provider MyApp.RAG.query
 ```
 
-The provider receives a `Tribunal.TestCase` struct with `input` and `context`, and returns the actual output string.
+The provider contracts intentionally follow each mode. `tribunal_eval` passes `test_case.input`, so the provider behaves like an ordinary application function inside ExUnit. `mix tribunal.eval` passes the full `Tribunal.TestCase` so batch providers can also inspect context, expected output, and metadata. Both return the actual output string.
 
 ## CI Integration Examples
 

--- a/guides/evaluation-modes.md
+++ b/guides/evaluation-modes.md
@@ -96,7 +96,7 @@ Use the mix task when you want to track aggregate performance across many test c
 ### Running with Thresholds
 
 ```bash
-# Default: always exit 0, just report results
+# Default: report quality failures without blocking
 mix tribunal.eval
 
 # Pass if 80% of tests succeed
@@ -108,6 +108,8 @@ mix tribunal.eval --threshold 0.9 --concurrency 5
 # Strict mode: fail on any failure (like ExUnit)
 mix tribunal.eval --strict
 ```
+
+Provider failures, task exits, timeouts, invalid evaluation configuration, and runs that select zero cases still exit nonzero without a quality gate.
 
 ### Output
 

--- a/guides/exunit-integration.md
+++ b/guides/exunit-integration.md
@@ -243,13 +243,13 @@ All LLM-as-judge assertions accept these options:
 ```elixir
 assert_faithful response,
   context: @context,
-  model: "anthropic:claude-3-5-sonnet-latest",  # override default model
+  model: "anthropic:claude-sonnet-4-6",  # override default model
   threshold: 0.9,                                # pass/fail threshold
   temperature: 0.0,                              # LLM temperature
   max_tokens: 500                                # max response tokens
 ```
 
-Default model: `anthropic:claude-3-5-haiku-latest`
+Default model: `anthropic:claude-haiku-4-5-20251001`
 Default threshold: `0.8`
 
 ## Test Organization

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -86,7 +86,7 @@ This creates:
 Execute evaluations with configurable thresholds:
 
 ```bash
-# Run all evals in test/evals/ (default: exit 0, just report)
+# Run all evals in test/evals/ (quality failures are report-only by default)
 mix tribunal.eval
 
 # Run specific dataset

--- a/guides/github-actions.md
+++ b/guides/github-actions.md
@@ -88,14 +88,14 @@ Use JUnit format for GitHub's built-in test reporting:
 
 ## Pass/Fail Strategies
 
-### Always Pass (Baseline Tracking)
+### Report-Only Quality Tracking
 
-By default, `mix tribunal.eval` exits 0 regardless of results. Use this for tracking baselines without blocking PRs:
+By default, ordinary quality failures do not block the workflow. Execution and configuration errors still exit nonzero, including provider failures, timeouts, and runs that select zero cases.
 
 ```yaml
 - name: Run evaluations (tracking only)
   run: mix tribunal.eval --format json --output results.json
-  # Always succeeds, results stored for comparison
+  # Quality failures are stored for comparison without blocking
 ```
 
 ### Threshold-Based Gating

--- a/guides/llm-as-judge.md
+++ b/guides/llm-as-judge.md
@@ -27,17 +27,17 @@ Set the default judge model in your application config:
 
 ```elixir
 # config/config.exs or config/dev.exs
-config :tribunal, llm: "anthropic:claude-3-5-sonnet-latest"
+config :tribunal, llm: "anthropic:claude-sonnet-4-6"
 ```
 
 ### Default Model
 
-The default judge model is `anthropic:claude-3-5-haiku-latest`. Override per assertion:
+The default judge model is `anthropic:claude-haiku-4-5-20251001`. Override per assertion:
 
 ```elixir
 assert_faithful response,
   context: @docs,
-  model: "anthropic:claude-3-5-sonnet-latest"
+  model: "anthropic:claude-sonnet-4-6"
 ```
 
 Or use any model supported by ReqLLM:

--- a/guides/reporters.md
+++ b/guides/reporters.md
@@ -122,6 +122,7 @@ Output:
     "total": 10,
     "passed": 8,
     "failed": 2,
+    "errors": 0,
     "pass_rate": 0.8,
     "duration_ms": 1500,
     "gate_status": "not_configured",
@@ -143,6 +144,7 @@ Output:
     {
       "input": "How do I Y?",
       "status": "failed",
+      "execution_error": false,
       "failures": [{"faithful": "Not grounded"}],
       "results": {"faithful": {"fail": {"reason": "Not grounded"}}},
       "evaluations": [{"faithful": {"fail": {"reason": "Not grounded"}}}],
@@ -154,7 +156,7 @@ Output:
 
 `results` contains one conservative summary per assertion type. When an assertion type is repeated, a failure or error wins over a pass. `evaluations` preserves every assertion execution in dataset order.
 
-Schema version 2 distinguishes quality-gate state from execution results. `summary.threshold_passed` is `null` when no gate was configured, and `summary.gate_status` is `"not_configured"`. This keeps report-only runs from being labeled as passing gates while they still exit successfully.
+Schema version 2 distinguishes quality-gate state from execution results. `summary.threshold_passed` is `null` when no gate was configured, and `summary.gate_status` is `"not_configured"`. This keeps report-only runs from being labeled as passing gates while they still exit successfully. Provider failures, task exits, timeouts, missing outputs, and assertion errors increment `summary.errors`, set `gate_status` to `"error"`, and exit nonzero even in report-only mode.
 
 ## HTML Reporter
 

--- a/guides/reporters.md
+++ b/guides/reporters.md
@@ -105,7 +105,7 @@ Key differences from Console:
 
 ## JSON Reporter
 
-Machine-readable JSON output.
+Machine-readable JSON output. `Tribunal.Reporter.JSON.format/1` is a pass-through formatter for a report map you construct. The versioned schema below is produced by `mix tribunal.eval --format json`, which adds batch summary and gate fields before formatting.
 
 ```elixir
 alias Tribunal.Reporter.JSON
@@ -117,12 +117,17 @@ output = JSON.format(report)
 Output:
 ```json
 {
+  "schema_version": 2,
   "summary": {
     "total": 10,
     "passed": 8,
     "failed": 2,
-    "pass_rate": 80.0,
-    "duration_ms": 1500
+    "pass_rate": 0.8,
+    "duration_ms": 1500,
+    "gate_status": "not_configured",
+    "threshold_passed": null,
+    "threshold": null,
+    "strict": false
   },
   "metrics": {
     "contains": {"passed": 5, "total": 5},
@@ -138,12 +143,18 @@ Output:
     {
       "input": "How do I Y?",
       "status": "failed",
-      "failures": [["faithful", "Not grounded"]],
+      "failures": [{"faithful": "Not grounded"}],
+      "results": {"faithful": {"fail": {"reason": "Not grounded"}}},
+      "evaluations": [{"faithful": {"fail": {"reason": "Not grounded"}}}],
       "duration_ms": 200
     }
   ]
 }
 ```
+
+`results` contains one conservative summary per assertion type. When an assertion type is repeated, a failure or error wins over a pass. `evaluations` preserves every assertion execution in dataset order.
+
+Schema version 2 distinguishes quality-gate state from execution results. `summary.threshold_passed` is `null` when no gate was configured, and `summary.gate_status` is `"not_configured"`. This keeps report-only runs from being labeled as passing gates while they still exit successfully.
 
 ## HTML Reporter
 

--- a/guides/reporters.md
+++ b/guides/reporters.md
@@ -137,8 +137,12 @@ Output:
   "cases": [
     {
       "input": "What is X?",
+      "actual_output": "X is the expected answer.",
       "status": "passed",
+      "execution_error": false,
       "failures": [],
+      "results": {"contains": {"pass": {"matched": ["X"]}}},
+      "evaluations": [{"contains": {"pass": {"matched": ["X"]}}}],
       "duration_ms": 100
     },
     {
@@ -156,7 +160,7 @@ Output:
 
 `results` contains one conservative summary per assertion type. When an assertion type is repeated, a failure or error wins over a pass. `evaluations` preserves every assertion execution in dataset order.
 
-Schema version 2 distinguishes quality-gate state from execution results. `summary.threshold_passed` is `null` when no gate was configured, and `summary.gate_status` is `"not_configured"`. This keeps report-only runs from being labeled as passing gates while they still exit successfully. Provider failures, task exits, timeouts, missing outputs, and assertion errors increment `summary.errors`, set `gate_status` to `"error"`, and exit nonzero even in report-only mode.
+Schema version 2 distinguishes quality-gate state from execution results. Whenever no gate is configured, `summary.threshold_passed` is `null`. A successful report-only run uses `summary.gate_status: "not_configured"`. Provider failures, task exits, timeouts, missing outputs, and assertion errors increment `summary.errors`, set `gate_status` to `"error"`, and exit nonzero. Selecting zero cases also exits nonzero with `gate_status: "failed"`.
 
 ## HTML Reporter
 

--- a/lib/mix/tasks/tribunal.ex
+++ b/lib/mix/tasks/tribunal.ex
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Tribunal.Eval do
     * `--format` - Output format: console (default), text, json, html, github, junit
     * `--output` - Write results to file instead of stdout
     * `--provider` - Module.function to call for each test case (e.g. MyApp.Agent.query)
-    * `--threshold` - Minimum pass rate (0.0-1.0) required. Default: none (always exit 0)
+    * `--threshold` - Minimum pass rate (0.0-1.0) required. Default: none (non-empty runs exit 0 after reporting)
     * `--strict` - Fail on any failure, equivalent to --threshold 1.0 (for CI gates)
     * `--concurrency` - Number of test cases to run in parallel. Default: 1 (sequential)
     * `--limit` - Maximum number of test cases to evaluate
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Tribunal.Eval do
       # GitHub Actions annotations
       mix tribunal.eval --format github
 
-      # Default: always exit 0 (for baseline tracking)
+      # Default: complete without a quality gate (for baseline tracking)
       mix tribunal.eval
 
       # Fail if pass rate < 80%
@@ -78,69 +78,94 @@ defmodule Mix.Tasks.Tribunal.Eval do
 
   @impl Mix.Task
   def run(args) do
-    {opts, files, invalid} =
-      OptionParser.parse(args,
-        strict: [
-          format: :string,
-          output: :string,
-          provider: :string,
-          threshold: :float,
-          strict: :boolean,
-          concurrency: :integer,
-          limit: :integer,
-          offset: :integer
-        ]
-      )
+    {opts, files, invalid} = parse_args(args)
 
     validate_options!(opts, invalid)
 
     # Start the app to load modules
     Mix.Task.run("app.start")
 
-    format = opts[:format] || "console"
-    output = opts[:output]
-    provider = parse_provider(opts[:provider])
-    threshold = opts[:threshold]
-    strict = opts[:strict] || false
-    concurrency = opts[:concurrency] || 1
-    limit = opts[:limit]
-    offset = opts[:offset] || 0
-
-    files = if Enum.empty?(files), do: find_default_files(), else: files
-
-    if Enum.empty?(files) do
-      Mix.raise("No eval files found. Create datasets in test/evals/")
-    end
+    settings = eval_settings(opts)
+    files = resolve_files!(files)
 
     start_time = System.monotonic_time(:millisecond)
 
     results =
       files
       |> Enum.flat_map(&load_dataset/1)
-      |> Enum.drop(offset)
-      |> then(fn cases -> if limit, do: Enum.take(cases, limit), else: cases end)
-      |> run_cases(provider, concurrency)
+      |> Enum.drop(settings.offset)
+      |> then(&limit_cases(&1, settings.limit))
+      |> run_cases(settings.provider, settings.concurrency)
       |> aggregate_results(start_time)
 
-    # Determine pass/fail based on threshold
-    passed = gate_passed?(results.summary, strict, threshold)
-
-    results = put_in(results, [:summary, :threshold_passed], passed)
-    results = put_in(results, [:summary, :threshold], threshold)
-    results = put_in(results, [:summary, :strict], strict)
-
-    formatted = format_results(results, format)
-
-    if output do
-      File.write!(output, formatted)
-      Mix.shell().info("Results written to #{output}")
-    else
-      Mix.shell().info(formatted)
-    end
+    {results, passed} = apply_gate(results, settings)
+    formatted = format_results(results, settings.format)
+    write_results(formatted, settings.output)
 
     unless passed do
       System.halt(1)
     end
+  end
+
+  defp parse_args(args) do
+    OptionParser.parse(args,
+      strict: [
+        format: :string,
+        output: :string,
+        provider: :string,
+        threshold: :float,
+        strict: :boolean,
+        concurrency: :integer,
+        limit: :integer,
+        offset: :integer
+      ]
+    )
+  end
+
+  defp eval_settings(opts) do
+    %{
+      format: opts[:format] || "console",
+      output: opts[:output],
+      provider: parse_provider(opts[:provider]),
+      threshold: opts[:threshold],
+      strict: opts[:strict] || false,
+      concurrency: opts[:concurrency] || 1,
+      limit: opts[:limit],
+      offset: opts[:offset] || 0
+    }
+  end
+
+  defp resolve_files!(files) do
+    files = if Enum.empty?(files), do: find_default_files(), else: files
+
+    if Enum.empty?(files) do
+      Mix.raise("No eval files found. Create datasets in test/evals/")
+    end
+
+    files
+  end
+
+  defp limit_cases(cases, nil), do: cases
+  defp limit_cases(cases, limit), do: Enum.take(cases, limit)
+
+  defp apply_gate(results, settings) do
+    gate_status = gate_status(results.summary, settings.strict, settings.threshold)
+    passed = gate_status in [:passed, :not_configured]
+    threshold_passed = if gate_status == :not_configured, do: nil, else: passed
+
+    results = put_in(results, [:summary, :threshold_passed], threshold_passed)
+    results = put_in(results, [:summary, :gate_status], gate_status)
+    results = put_in(results, [:summary, :threshold], settings.threshold)
+    results = put_in(results, [:summary, :strict], settings.strict)
+
+    {results, passed}
+  end
+
+  defp write_results(formatted, nil), do: Mix.shell().info(formatted)
+
+  defp write_results(formatted, output) do
+    File.write!(output, formatted)
+    Mix.shell().info("Results written to #{output}")
   end
 
   defp find_default_files do
@@ -154,6 +179,7 @@ defmodule Mix.Tasks.Tribunal.Eval do
     validate_positive!("--concurrency", opts[:concurrency])
     validate_positive!("--limit", opts[:limit])
     validate_offset!(opts[:offset])
+    validate_format!(opts[:format])
   end
 
   defp validate_known_options!([]), do: :ok
@@ -175,13 +201,19 @@ defmodule Mix.Tasks.Tribunal.Eval do
   defp validate_offset!(offset) when offset >= 0, do: :ok
   defp validate_offset!(_offset), do: Mix.raise("--offset cannot be negative")
 
-  defp gate_passed?(%{total: 0}, _strict, _threshold), do: false
-  defp gate_passed?(summary, true, _threshold), do: summary.failed == 0
+  defp validate_format!(nil), do: :ok
+  defp validate_format!(format) when format in ~w(console text json html github junit), do: :ok
+  defp validate_format!(format), do: Mix.raise("Unknown format: #{format}")
 
-  defp gate_passed?(summary, _strict, threshold) when is_number(threshold),
-    do: summary.pass_rate >= threshold
+  defp gate_status(%{total: 0}, _strict, _threshold), do: :failed
+  defp gate_status(%{failed: 0}, true, _threshold), do: :passed
+  defp gate_status(_summary, true, _threshold), do: :failed
 
-  defp gate_passed?(_summary, _strict, _threshold), do: true
+  defp gate_status(summary, _strict, threshold) when is_number(threshold) do
+    if summary.pass_rate >= threshold, do: :passed, else: :failed
+  end
+
+  defp gate_status(_summary, _strict, _threshold), do: :not_configured
 
   defp parse_provider(nil), do: nil
 
@@ -201,30 +233,34 @@ defmodule Mix.Tasks.Tribunal.Eval do
   end
 
   defp run_cases(cases, provider, concurrency) do
-    if concurrency > 1 do
-      task_results =
-        Task.async_stream(
-          cases,
-          fn {test_case, assertions} -> run_case(test_case, assertions, provider) end,
-          max_concurrency: concurrency,
-          timeout: 120_000
+    timeout = Application.get_env(:tribunal, :eval_timeout, 120_000)
+
+    task_results =
+      Task.Supervisor.async_stream_nolink(
+        Tribunal.TaskSupervisor,
+        cases,
+        fn {test_case, assertions} -> run_case(test_case, assertions, provider) end,
+        max_concurrency: concurrency,
+        timeout: timeout,
+        on_timeout: :kill_task
+      )
+
+    cases
+    |> Enum.zip(task_results)
+    |> Enum.map(fn
+      {_case, {:ok, result}} ->
+        result
+
+      {{test_case, assertions}, {:exit, reason}} ->
+        Tribunal.Evaluator.error(test_case, "Evaluation task failed: #{inspect(reason)}",
+          assertions: assertions,
+          duration_ms: task_error_duration(reason, timeout)
         )
-
-      cases
-      |> Enum.zip(task_results)
-      |> Enum.map(fn
-        {_case, {:ok, result}} ->
-          result
-
-        {{test_case, _assertions}, {:exit, reason}} ->
-          Tribunal.Evaluator.error(test_case, "Evaluation task failed: #{inspect(reason)}")
-      end)
-    else
-      Enum.map(cases, fn {test_case, assertions} ->
-        run_case(test_case, assertions, provider)
-      end)
-    end
+    end)
   end
+
+  defp task_error_duration(:timeout, timeout), do: timeout
+  defp task_error_duration(_reason, _timeout), do: 0
 
   defp run_case(test_case, assertions, provider) do
     start = System.monotonic_time(:millisecond)
@@ -234,7 +270,7 @@ defmodule Mix.Tasks.Tribunal.Eval do
         Tribunal.Evaluator.evaluate(test_case, assertions, started_at: start)
 
       {:error, reason} ->
-        Tribunal.Evaluator.error(test_case, reason, started_at: start)
+        Tribunal.Evaluator.error(test_case, reason, started_at: start, assertions: assertions)
     end
   end
 
@@ -259,6 +295,7 @@ defmodule Mix.Tasks.Tribunal.Eval do
     metrics = aggregate_metrics(cases)
 
     %{
+      schema_version: 2,
       summary: %{
         total: total,
         passed: passed,

--- a/lib/mix/tasks/tribunal.ex
+++ b/lib/mix/tasks/tribunal.ex
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Tribunal.Eval do
     * `--format` - Output format: console (default), text, json, html, github, junit
     * `--output` - Write results to file instead of stdout
     * `--provider` - Module.function to call for each test case (e.g. MyApp.Agent.query)
-    * `--threshold` - Minimum pass rate (0.0-1.0) required. Default: none (non-empty runs exit 0 after reporting)
+    * `--threshold` - Minimum pass rate (0.0-1.0) required. Default: none (quality failures are report-only)
     * `--strict` - Fail on any failure, equivalent to --threshold 1.0 (for CI gates)
     * `--concurrency` - Number of test cases to run in parallel. Default: 1 (sequential)
     * `--limit` - Maximum number of test cases to evaluate
@@ -149,7 +149,9 @@ defmodule Mix.Tasks.Tribunal.Eval do
   defp apply_gate(results, settings) do
     gate_status = gate_status(results.summary, settings.strict, settings.threshold)
     passed = gate_status in [:passed, :not_configured]
-    threshold_passed = if gate_status == :not_configured, do: nil, else: passed
+
+    threshold_passed =
+      if settings.strict or is_number(settings.threshold), do: gate_status == :passed, else: nil
 
     results = put_in(results, [:summary, :threshold_passed], threshold_passed)
     results = put_in(results, [:summary, :gate_status], gate_status)

--- a/lib/mix/tasks/tribunal.ex
+++ b/lib/mix/tasks/tribunal.ex
@@ -102,9 +102,7 @@ defmodule Mix.Tasks.Tribunal.Eval do
     formatted = format_results(results, settings.format)
     write_results(formatted, settings.output)
 
-    unless passed do
-      System.halt(1)
-    end
+    unless passed, do: Mix.raise("Evaluation failed")
   end
 
   defp parse_args(args) do
@@ -206,6 +204,7 @@ defmodule Mix.Tasks.Tribunal.Eval do
   defp validate_format!(format), do: Mix.raise("Unknown format: #{format}")
 
   defp gate_status(%{total: 0}, _strict, _threshold), do: :failed
+  defp gate_status(%{errors: errors}, _strict, _threshold) when errors > 0, do: :error
   defp gate_status(%{failed: 0}, true, _threshold), do: :passed
   defp gate_status(_summary, true, _threshold), do: :failed
 
@@ -290,6 +289,7 @@ defmodule Mix.Tasks.Tribunal.Eval do
 
     passed = Enum.count(cases, &(&1.status == :passed))
     failed = Enum.count(cases, &(&1.status == :failed))
+    errors = Enum.count(cases, &Map.get(&1, :execution_error, false))
     total = length(cases)
 
     metrics = aggregate_metrics(cases)
@@ -300,6 +300,7 @@ defmodule Mix.Tasks.Tribunal.Eval do
         total: total,
         passed: passed,
         failed: failed,
+        errors: errors,
         pass_rate: if(total > 0, do: passed / total, else: 0),
         duration_ms: duration
       },

--- a/lib/mix/tasks/tribunal.ex
+++ b/lib/mix/tasks/tribunal.ex
@@ -78,7 +78,7 @@ defmodule Mix.Tasks.Tribunal.Eval do
 
   @impl Mix.Task
   def run(args) do
-    {opts, files, _} =
+    {opts, files, invalid} =
       OptionParser.parse(args,
         strict: [
           format: :string,
@@ -91,6 +91,8 @@ defmodule Mix.Tasks.Tribunal.Eval do
           offset: :integer
         ]
       )
+
+    validate_options!(opts, invalid)
 
     # Start the app to load modules
     Mix.Task.run("app.start")
@@ -107,8 +109,7 @@ defmodule Mix.Tasks.Tribunal.Eval do
     files = if Enum.empty?(files), do: find_default_files(), else: files
 
     if Enum.empty?(files) do
-      Mix.shell().info("No eval files found. Create datasets in test/evals/")
-      System.halt(0)
+      Mix.raise("No eval files found. Create datasets in test/evals/")
     end
 
     start_time = System.monotonic_time(:millisecond)
@@ -122,12 +123,7 @@ defmodule Mix.Tasks.Tribunal.Eval do
       |> aggregate_results(start_time)
 
     # Determine pass/fail based on threshold
-    passed =
-      cond do
-        strict -> results.summary.failed == 0
-        is_number(threshold) -> results.summary.pass_rate >= threshold
-        true -> true
-      end
+    passed = gate_passed?(results.summary, strict, threshold)
 
     results = put_in(results, [:summary, :threshold_passed], passed)
     results = put_in(results, [:summary, :threshold], threshold)
@@ -152,6 +148,41 @@ defmodule Mix.Tasks.Tribunal.Eval do
     |> Enum.flat_map(&Path.wildcard/1)
   end
 
+  defp validate_options!(opts, invalid) do
+    validate_known_options!(invalid)
+    validate_threshold!(opts[:threshold])
+    validate_positive!("--concurrency", opts[:concurrency])
+    validate_positive!("--limit", opts[:limit])
+    validate_offset!(opts[:offset])
+  end
+
+  defp validate_known_options!([]), do: :ok
+
+  defp validate_known_options!(invalid) do
+    formatted = Enum.map_join(invalid, ", ", fn {option, value} -> inspect({option, value}) end)
+    Mix.raise("Invalid options: #{formatted}")
+  end
+
+  defp validate_threshold!(nil), do: :ok
+  defp validate_threshold!(threshold) when threshold >= 0 and threshold <= 1, do: :ok
+  defp validate_threshold!(_threshold), do: Mix.raise("--threshold must be between 0.0 and 1.0")
+
+  defp validate_positive!(_name, nil), do: :ok
+  defp validate_positive!(_name, value) when value >= 1, do: :ok
+  defp validate_positive!(name, _value), do: Mix.raise("#{name} must be at least 1")
+
+  defp validate_offset!(nil), do: :ok
+  defp validate_offset!(offset) when offset >= 0, do: :ok
+  defp validate_offset!(_offset), do: Mix.raise("--offset cannot be negative")
+
+  defp gate_passed?(%{total: 0}, _strict, _threshold), do: false
+  defp gate_passed?(summary, true, _threshold), do: summary.failed == 0
+
+  defp gate_passed?(summary, _strict, threshold) when is_number(threshold),
+    do: summary.pass_rate >= threshold
+
+  defp gate_passed?(_summary, _strict, _threshold), do: true
+
   defp parse_provider(nil), do: nil
 
   defp parse_provider(str) do
@@ -171,13 +202,23 @@ defmodule Mix.Tasks.Tribunal.Eval do
 
   defp run_cases(cases, provider, concurrency) do
     if concurrency > 1 do
+      task_results =
+        Task.async_stream(
+          cases,
+          fn {test_case, assertions} -> run_case(test_case, assertions, provider) end,
+          max_concurrency: concurrency,
+          timeout: 120_000
+        )
+
       cases
-      |> Task.async_stream(
-        fn {test_case, assertions} -> run_case(test_case, assertions, provider) end,
-        max_concurrency: concurrency,
-        timeout: 120_000
-      )
-      |> Enum.map(fn {:ok, result} -> result end)
+      |> Enum.zip(task_results)
+      |> Enum.map(fn
+        {_case, {:ok, result}} ->
+          result
+
+        {{test_case, _assertions}, {:exit, reason}} ->
+          Tribunal.Evaluator.error(test_case, "Evaluation task failed: #{inspect(reason)}")
+      end)
     else
       Enum.map(cases, fn {test_case, assertions} ->
         run_case(test_case, assertions, provider)
@@ -188,37 +229,24 @@ defmodule Mix.Tasks.Tribunal.Eval do
   defp run_case(test_case, assertions, provider) do
     start = System.monotonic_time(:millisecond)
 
-    test_case =
-      if provider do
-        {mod, fun} = provider
-        output = apply(mod, fun, [test_case])
-        Tribunal.TestCase.with_output(test_case, output)
-      else
-        test_case
-      end
+    case populate_output(test_case, provider) do
+      {:ok, test_case} ->
+        Tribunal.Evaluator.evaluate(test_case, assertions, started_at: start)
 
-    results =
-      if test_case.actual_output do
-        Tribunal.Assertions.evaluate_all(assertions, test_case)
-      else
-        %{}
-      end
+      {:error, reason} ->
+        Tribunal.Evaluator.error(test_case, reason, started_at: start)
+    end
+  end
 
-    duration = System.monotonic_time(:millisecond) - start
+  defp populate_output(test_case, nil), do: {:ok, test_case}
 
-    failures =
-      results
-      |> Enum.filter(fn {_type, result} -> match?({:fail, _}, result) end)
-      |> Enum.map(fn {type, {:fail, details}} -> {type, details[:reason]} end)
-
-    %{
-      input: test_case.input,
-      actual_output: test_case.actual_output,
-      status: if(Enum.empty?(failures), do: :passed, else: :failed),
-      failures: failures,
-      results: results,
-      duration_ms: duration
-    }
+  defp populate_output(test_case, {mod, fun}) do
+    output = apply(mod, fun, [test_case])
+    {:ok, Tribunal.TestCase.with_output(test_case, output)}
+  rescue
+    error -> {:error, Exception.message(error)}
+  catch
+    kind, reason -> {:error, "#{kind}: #{inspect(reason)}"}
   end
 
   defp aggregate_results(cases, start_time) do
@@ -246,7 +274,7 @@ defmodule Mix.Tasks.Tribunal.Eval do
   defp aggregate_metrics(cases) do
     cases
     |> Enum.flat_map(fn c ->
-      Enum.map(c.results, fn {type, result} ->
+      Enum.map(Map.get(c, :evaluations, c.results), fn {type, result} ->
         {type, match?({:pass, _}, result)}
       end)
     end)

--- a/lib/mix/tasks/tribunal/redteam_generate.ex
+++ b/lib/mix/tasks/tribunal/redteam_generate.ex
@@ -42,6 +42,7 @@ defmodule Mix.Tasks.Tribunal.Redteam.Generate do
   use Mix.Task
 
   alias Tribunal.RedTeam
+  alias Tribunal.RedTeam.Plugin
   alias Tribunal.RedTeam.YamlEmit
 
   @impl Mix.Task
@@ -92,7 +93,16 @@ defmodule Mix.Tasks.Tribunal.Redteam.Generate do
       raw ->
         raw
         |> String.split(",", trim: true)
-        |> Enum.map(&String.to_atom(String.trim(&1)))
+        |> Enum.map(&resolve_plugin!/1)
+    end
+  end
+
+  defp resolve_plugin!(raw_id) do
+    id = String.trim(raw_id)
+
+    case Enum.find(Plugin.all_ids(), &(Atom.to_string(&1) == id)) do
+      nil -> Mix.raise("Unknown red-team plugin: #{id}")
+      plugin_id -> plugin_id
     end
   end
 

--- a/lib/tribunal/application.ex
+++ b/lib/tribunal/application.ex
@@ -8,8 +8,7 @@ defmodule Tribunal.Application do
   @impl true
   def start(_type, _args) do
     children = [
-      # Starts a worker by calling: Tribunal.Worker.start_link(arg)
-      # {Tribunal.Worker, arg}
+      {Task.Supervisor, name: Tribunal.TaskSupervisor}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/tribunal/assertions.ex
+++ b/lib/tribunal/assertions.ex
@@ -40,7 +40,9 @@ defmodule Tribunal.Assertions do
 
   Returns `{:pass, details}` or `{:fail, details}`.
   """
-  def evaluate(assertion_type, %TestCase{} = test_case, opts \\ []) do
+  def evaluate(assertion_type, test_case, opts \\ [])
+
+  def evaluate(assertion_type, %TestCase{} = test_case, opts) when is_atom(assertion_type) do
     cond do
       assertion_type in @deterministic_assertions ->
         Deterministic.evaluate(assertion_type, test_case.actual_output, opts)
@@ -55,6 +57,10 @@ defmodule Tribunal.Assertions do
       true ->
         {:error, "Unknown assertion type: #{assertion_type}"}
     end
+  end
+
+  def evaluate(assertion_type, %TestCase{}, _opts) do
+    {:error, "Unknown assertion type: #{assertion_type}"}
   end
 
   @doc """
@@ -73,6 +79,35 @@ defmodule Tribunal.Assertions do
     assertions
     |> Enum.to_list()
     |> evaluate_all(test_case)
+  end
+
+  @doc """
+  Evaluates assertions in order without collapsing repeated assertion types.
+
+  Default options are applied to every assertion. Options declared on the
+  assertion take precedence over defaults.
+  """
+  def evaluate_each(assertions, test_case, defaults \\ [])
+
+  def evaluate_each(assertions, %TestCase{} = test_case, defaults) when is_map(assertions) do
+    assertions
+    |> Enum.to_list()
+    |> evaluate_each(test_case, defaults)
+  end
+
+  def evaluate_each(assertions, %TestCase{} = test_case, defaults) when is_list(assertions) do
+    defaults = normalize_opts(defaults)
+
+    Enum.map(assertions, fn
+      {type, opts} ->
+        case merge_opts(defaults, opts) do
+          {:ok, merged_opts} -> {type, safely_evaluate(type, test_case, merged_opts)}
+          {:error, reason} -> {type, {:error, reason}}
+        end
+
+      type when is_atom(type) or is_binary(type) ->
+        {type, safely_evaluate(type, test_case, defaults)}
+    end)
   end
 
   @doc """
@@ -129,5 +164,26 @@ defmodule Tribunal.Assertions do
     end
 
     Embedding.evaluate(test_case, opts)
+  end
+
+  defp safely_evaluate(type, test_case, opts) do
+    evaluate(type, test_case, opts)
+  rescue
+    error -> {:error, Exception.message(error)}
+  catch
+    kind, reason -> {:error, "#{kind}: #{inspect(reason)}"}
+  end
+
+  defp normalize_opts(opts) when is_map(opts), do: Map.to_list(opts)
+  defp normalize_opts(opts) when is_list(opts), do: opts
+
+  defp merge_opts(defaults, opts) do
+    opts = normalize_opts(opts)
+
+    if Keyword.keyword?(defaults) and Keyword.keyword?(opts) do
+      {:ok, Keyword.merge(defaults, opts)}
+    else
+      {:error, "Assertion options must use known atom keys"}
+    end
   end
 end

--- a/lib/tribunal/assertions.ex
+++ b/lib/tribunal/assertions.ex
@@ -270,7 +270,7 @@ defmodule Tribunal.Assertions do
   defp normalize_opts(opts) when is_map(opts), do: Map.to_list(opts)
   defp normalize_opts(opts) when is_list(opts), do: opts
 
-  defp merge_opts(defaults, opts) do
+  defp merge_opts(defaults, opts) when is_map(opts) or is_list(opts) do
     opts = normalize_opts(opts)
 
     if Keyword.keyword?(defaults) and Keyword.keyword?(opts) do
@@ -279,6 +279,8 @@ defmodule Tribunal.Assertions do
       {:error, "Assertion options must use known atom keys"}
     end
   end
+
+  defp merge_opts(_defaults, _opts), do: {:error, "Assertion options must be a keyword list"}
 
   defp worst_result({:error, _} = error, _result), do: error
   defp worst_result(_existing, {:error, _} = error), do: error

--- a/lib/tribunal/assertions.ex
+++ b/lib/tribunal/assertions.ex
@@ -35,6 +35,49 @@ defmodule Tribunal.Assertions do
 
   @embedding_assertions [:similar]
 
+  @deterministic_options %{
+    contains: [:value, :values],
+    not_contains: [:value, :values],
+    contains_any: [:value, :values],
+    contains_all: [:value, :values],
+    regex: [:value, :pattern],
+    is_json: [],
+    max_tokens: [:value, :max],
+    latency_ms: [:value, :max, :actual, :latency],
+    starts_with: [:value],
+    ends_with: [:value],
+    equals: [:value],
+    min_length: [:value, :min],
+    max_length: [:value, :max],
+    word_count: [:min, :max],
+    is_url: [],
+    is_email: [],
+    levenshtein: [:value, :max_distance]
+  }
+
+  @judge_options [
+    :threshold,
+    :model,
+    :llm,
+    :llm_client,
+    :temperature,
+    :max_tokens,
+    :verbose,
+    :purpose,
+    :policy,
+    :context,
+    :query,
+    :expected,
+    :input
+  ]
+
+  @doc false
+  def resolve_type(type) when is_atom(type), do: type
+
+  def resolve_type(type) when is_binary(type) do
+    Enum.find(registered_types(), type, &(Atom.to_string(&1) == type))
+  end
+
   @doc """
   Evaluates a single assertion against a test case.
 
@@ -43,19 +86,21 @@ defmodule Tribunal.Assertions do
   def evaluate(assertion_type, test_case, opts \\ [])
 
   def evaluate(assertion_type, %TestCase{} = test_case, opts) when is_atom(assertion_type) do
-    cond do
-      assertion_type in @deterministic_assertions ->
-        Deterministic.evaluate(assertion_type, test_case.actual_output, opts)
+    with :ok <- validate_options(assertion_type, opts) do
+      cond do
+        assertion_type in @deterministic_assertions ->
+          Deterministic.evaluate(assertion_type, test_case.actual_output, opts)
 
-      Tribunal.Judge.builtin_judge?(assertion_type) or
-          Tribunal.Judge.custom_judge?(assertion_type) ->
-        evaluate_judge(assertion_type, test_case, opts)
+        Tribunal.Judge.builtin_judge?(assertion_type) or
+            Tribunal.Judge.custom_judge?(assertion_type) ->
+          evaluate_judge(assertion_type, test_case, opts)
 
-      assertion_type in @embedding_assertions ->
-        evaluate_embedding(assertion_type, test_case, opts)
+        assertion_type in @embedding_assertions ->
+          evaluate_embedding(assertion_type, test_case, opts)
 
-      true ->
-        {:error, "Unknown assertion type: #{assertion_type}"}
+        true ->
+          {:error, "Unknown assertion type: #{assertion_type}"}
+      end
     end
   end
 
@@ -69,10 +114,9 @@ defmodule Tribunal.Assertions do
   Returns a map of `%{assertion_type => result}`.
   """
   def evaluate_all(assertions, %TestCase{} = test_case) when is_list(assertions) do
-    Map.new(assertions, fn
-      {type, opts} -> {type, evaluate(type, test_case, opts)}
-      type when is_atom(type) -> {type, evaluate(type, test_case, [])}
-    end)
+    assertions
+    |> evaluate_each(test_case)
+    |> summarize()
   end
 
   def evaluate_all(assertions, %TestCase{} = test_case) when is_map(assertions) do
@@ -100,13 +144,20 @@ defmodule Tribunal.Assertions do
 
     Enum.map(assertions, fn
       {type, opts} ->
-        case merge_opts(defaults, opts) do
+        case merge_opts(defaults_for(type, defaults), opts) do
           {:ok, merged_opts} -> {type, safely_evaluate(type, test_case, merged_opts)}
           {:error, reason} -> {type, {:error, reason}}
         end
 
       type when is_atom(type) or is_binary(type) ->
-        {type, safely_evaluate(type, test_case, defaults)}
+        {type, safely_evaluate(type, test_case, defaults_for(type, defaults))}
+    end)
+  end
+
+  @doc false
+  def summarize(evaluations) do
+    Enum.reduce(evaluations, %{}, fn {type, result}, summary ->
+      Map.update(summary, type, result, &worst_result(&1, result))
     end)
   end
 
@@ -114,7 +165,8 @@ defmodule Tribunal.Assertions do
   Checks if all assertions passed.
   """
   def all_passed?(results) when is_map(results) do
-    Enum.all?(results, fn {_type, result} -> match?({:pass, _}, result) end)
+    map_size(results) > 0 and
+      Enum.all?(results, fn {_type, result} -> match?({:pass, _}, result) end)
   end
 
   @doc """
@@ -138,6 +190,47 @@ defmodule Tribunal.Assertions do
       end
 
     base ++ judge ++ embedding
+  end
+
+  defp registered_types do
+    @deterministic_assertions ++ @embedding_assertions ++ Tribunal.Judge.all_judge_names()
+  end
+
+  defp validate_options(type, opts) when is_list(opts) do
+    cond do
+      not Keyword.keyword?(opts) ->
+        {:error, "Assertion options must use known atom keys"}
+
+      Tribunal.Judge.custom_judge?(type) ->
+        :ok
+
+      allowed = allowed_options(type) ->
+        case Keyword.keys(opts) -- allowed do
+          [] -> :ok
+          unknown -> {:error, "Unknown options for #{type}: #{inspect(unknown)}"}
+        end
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_options(_type, _opts), do: {:error, "Assertion options must be a keyword list"}
+
+  defp allowed_options(type) when type in @embedding_assertions,
+    do: [:threshold, :alike_fn, :expected, :verbose]
+
+  defp allowed_options(type), do: Map.get(@deterministic_options, type) || judge_options(type)
+
+  defp judge_options(type) do
+    if type in Tribunal.Judge.builtin_judge_names(), do: @judge_options
+  end
+
+  defp defaults_for(type, defaults) do
+    case allowed_options(type) do
+      nil -> defaults
+      allowed -> Keyword.take(defaults, allowed)
+    end
   end
 
   defp evaluate_judge(type, test_case, opts) do
@@ -186,4 +279,10 @@ defmodule Tribunal.Assertions do
       {:error, "Assertion options must use known atom keys"}
     end
   end
+
+  defp worst_result({:error, _} = error, _result), do: error
+  defp worst_result(_existing, {:error, _} = error), do: error
+  defp worst_result({:fail, _} = failure, _result), do: failure
+  defp worst_result(_existing, {:fail, _} = failure), do: failure
+  defp worst_result(_existing, result), do: result
 end

--- a/lib/tribunal/assertions/deterministic.ex
+++ b/lib/tribunal/assertions/deterministic.ex
@@ -55,12 +55,16 @@ defmodule Tribunal.Assertions.Deterministic do
   def evaluate(:contains_any, output, opts) do
     values = List.wrap(opts[:value] || opts[:values])
 
-    found = Enum.find(values, &String.contains?(output, &1))
-
-    if found do
-      {:pass, %{matched: found}}
+    if values == [] do
+      {:error, "contains_any requires :value or :values"}
     else
-      {:fail, %{expected_any: values, reason: "Output contains none of: #{inspect(values)}"}}
+      found = Enum.find(values, &String.contains?(output, &1))
+
+      if found do
+        {:pass, %{matched: found}}
+      else
+        {:fail, %{expected_any: values, reason: "Output contains none of: #{inspect(values)}"}}
+      end
     end
   end
 

--- a/lib/tribunal/assertions/deterministic.ex
+++ b/lib/tribunal/assertions/deterministic.ex
@@ -35,30 +35,20 @@ defmodule Tribunal.Assertions.Deterministic do
   def evaluate(:contains, output, opts) do
     values = List.wrap(opts[:value] || opts[:values])
 
-    results =
-      Enum.map(values, fn v ->
-        {v, String.contains?(output, v)}
-      end)
-
-    if Enum.all?(results, fn {_, matched} -> matched end) do
-      {:pass, %{matched: values}}
+    if values == [] do
+      {:error, "contains requires :value or :values"}
     else
-      missing = results |> Enum.reject(fn {_, m} -> m end) |> Enum.map(fn {v, _} -> v end)
-      {:fail, %{missing: missing, reason: "Output missing: #{inspect(missing)}"}}
+      evaluate_contains(output, values)
     end
   end
 
   def evaluate(:not_contains, output, opts) do
     values = List.wrap(opts[:value] || opts[:values])
 
-    found =
-      values
-      |> Enum.filter(&String.contains?(output, &1))
-
-    if Enum.empty?(found) do
-      {:pass, %{checked: values}}
+    if values == [] do
+      {:error, "not_contains requires :value or :values"}
     else
-      {:fail, %{found: found, reason: "Output contains forbidden: #{inspect(found)}"}}
+      evaluate_not_contains(output, values)
     end
   end
 
@@ -77,16 +67,10 @@ defmodule Tribunal.Assertions.Deterministic do
   def evaluate(:contains_all, output, opts) do
     values = List.wrap(opts[:value] || opts[:values])
 
-    results =
-      Enum.map(values, fn v ->
-        {v, String.contains?(output, v)}
-      end)
-
-    if Enum.all?(results, fn {_, matched} -> matched end) do
-      {:pass, %{matched: values}}
+    if values == [] do
+      {:error, "contains_all requires :value or :values"}
     else
-      missing = results |> Enum.reject(fn {_, m} -> m end) |> Enum.map(fn {v, _} -> v end)
-      {:fail, %{missing: missing, reason: "Output missing: #{inspect(missing)}"}}
+      evaluate_contains_all(output, values)
     end
   end
 
@@ -260,6 +244,29 @@ defmodule Tribunal.Assertions.Deterministic do
        }}
     end
   end
+
+  defp evaluate_contains(output, values) do
+    results = Enum.map(values, &{&1, String.contains?(output, &1)})
+
+    if Enum.all?(results, fn {_, matched} -> matched end) do
+      {:pass, %{matched: values}}
+    else
+      missing = results |> Enum.reject(fn {_, matched} -> matched end) |> Enum.map(&elem(&1, 0))
+      {:fail, %{missing: missing, reason: "Output missing: #{inspect(missing)}"}}
+    end
+  end
+
+  defp evaluate_not_contains(output, values) do
+    found = Enum.filter(values, &String.contains?(output, &1))
+
+    if Enum.empty?(found) do
+      {:pass, %{checked: values}}
+    else
+      {:fail, %{found: found, reason: "Output contains forbidden: #{inspect(found)}"}}
+    end
+  end
+
+  defp evaluate_contains_all(output, values), do: evaluate_contains(output, values)
 
   # Levenshtein distance algorithm
   defp levenshtein_distance(s1, s2) do

--- a/lib/tribunal/assertions/judge.ex
+++ b/lib/tribunal/assertions/judge.ex
@@ -87,7 +87,7 @@ defmodule Tribunal.Assertions.Judge do
 
   defp call_llm(model, messages, opts) do
     # Allow injecting custom LLM for tests via opts[:llm]
-    case opts[:llm] do
+    case opts[:llm] || opts[:llm_client] do
       nil ->
         call_req_llm(model, messages, opts)
 

--- a/lib/tribunal/assertions/judge.ex
+++ b/lib/tribunal/assertions/judge.ex
@@ -6,7 +6,7 @@ defmodule Tribunal.Assertions.Judge do
   verdicts from the judge model.
   """
 
-  @default_model "anthropic:claude-3-5-haiku-latest"
+  @default_model "anthropic:claude-haiku-4-5-20251001"
   @default_threshold 0.8
 
   @schema [
@@ -134,8 +134,13 @@ defmodule Tribunal.Assertions.Judge do
   defp verdict_result("yes", _score, _threshold, false, details), do: {:pass, details}
   defp verdict_result("no", _score, _threshold, false, details), do: {:fail, details}
 
-  defp verdict_result("partial", score, threshold, _negative?, details)
+  defp verdict_result("partial", score, threshold, false, details)
        when is_number(score) and score >= threshold do
+    {:pass, details}
+  end
+
+  defp verdict_result("partial", score, threshold, true, details)
+       when is_number(score) and score <= threshold do
     {:pass, details}
   end
 

--- a/lib/tribunal/dataset.ex
+++ b/lib/tribunal/dataset.ex
@@ -133,15 +133,26 @@ defmodule Tribunal.Dataset do
     end)
   end
 
-  defp normalize_type(type) when is_binary(type), do: String.to_atom(type)
+  defp normalize_type(type) when is_binary(type) do
+    String.to_existing_atom(type)
+  rescue
+    ArgumentError -> type
+  end
+
   defp normalize_type(type) when is_atom(type), do: type
 
   defp normalize_opts(opts) when is_map(opts) do
     Enum.map(opts, fn
-      {k, v} when is_binary(k) -> {String.to_atom(k), v}
+      {k, v} when is_binary(k) -> {existing_atom_or_string(k), v}
       {k, v} when is_atom(k) -> {k, v}
     end)
   end
 
   defp normalize_opts(opts) when is_list(opts), do: opts
+
+  defp existing_atom_or_string(value) do
+    String.to_existing_atom(value)
+  rescue
+    ArgumentError -> value
+  end
 end

--- a/lib/tribunal/dataset.ex
+++ b/lib/tribunal/dataset.ex
@@ -36,6 +36,11 @@ defmodule Tribunal.Dataset do
 
   alias Tribunal.TestCase
 
+  @known_option_keys ~w(
+    actual alike_fn context expected latency llm max max_distance max_tokens min model
+    pattern policy purpose query temperature threshold value values verbose
+  )a
+
   @doc """
   Loads a dataset from a file path.
 
@@ -43,7 +48,8 @@ defmodule Tribunal.Dataset do
   """
   def load(path) do
     with {:ok, content} <- File.read(path),
-         {:ok, data} <- parse(path, content) do
+         {:ok, data} <- parse(path, content),
+         :ok <- validate(data) do
       test_cases = Enum.map(data, &to_test_case/1)
       {:ok, test_cases}
     end
@@ -66,7 +72,8 @@ defmodule Tribunal.Dataset do
   """
   def load_with_assertions(path) do
     with {:ok, content} <- File.read(path),
-         {:ok, data} <- parse(path, content) do
+         {:ok, data} <- parse(path, content),
+         :ok <- validate(data) do
       cases =
         Enum.map(data, fn item ->
           test_case = to_test_case(item)
@@ -107,6 +114,118 @@ defmodule Tribunal.Dataset do
     TestCase.new(item)
   end
 
+  defp validate(data) when not is_list(data),
+    do: {:error, {:invalid_dataset, "top-level value must be a list"}}
+
+  defp validate(data) do
+    data
+    |> Enum.with_index()
+    |> Enum.reduce_while(:ok, fn {item, index}, :ok ->
+      case validate_item(item) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, {:invalid_case, index, reason}}}
+      end
+    end)
+  end
+
+  defp validate_item(item) when not is_map(item), do: {:error, "case must be an object"}
+
+  defp validate_item(item) do
+    input = field(item, "input", :input)
+    expected = field(item, "expected", :expected)
+
+    with :ok <- validate_case_keys(item),
+         :ok <- require_string(input, "input"),
+         :ok <- optional_string(field(item, "actual_output", :actual_output), "actual_output"),
+         :ok <-
+           optional_string(field(item, "expected_output", :expected_output), "expected_output"),
+         :ok <- optional_context(field(item, "context", :context), "context"),
+         :ok <-
+           optional_context(
+             field(item, "retrieval_context", :retrieval_context),
+             "retrieval_context"
+           ),
+         :ok <- optional_map(field(item, "metadata", :metadata), "metadata") do
+      validate_expected(expected)
+    end
+  end
+
+  defp validate_case_keys(item) do
+    if Enum.all?(Map.keys(item), &(is_binary(&1) or is_atom(&1))) do
+      :ok
+    else
+      {:error, "case field names must be strings or atoms"}
+    end
+  end
+
+  defp field(item, string_key, atom_key) do
+    case Map.fetch(item, string_key) do
+      {:ok, value} -> value
+      :error -> Map.get(item, atom_key)
+    end
+  end
+
+  defp require_string(nil, field), do: {:error, "#{field} is required"}
+  defp require_string(value, _field) when is_binary(value), do: :ok
+  defp require_string(_value, field), do: {:error, "#{field} must be a string"}
+
+  defp optional_string(nil, _field), do: :ok
+  defp optional_string(value, _field) when is_binary(value), do: :ok
+  defp optional_string(_value, field), do: {:error, "#{field} must be a string"}
+
+  defp optional_context(nil, _field), do: :ok
+  defp optional_context(value, _field) when is_binary(value), do: :ok
+
+  defp optional_context(value, field) when is_list(value) do
+    if Enum.all?(value, &is_binary/1),
+      do: :ok,
+      else: {:error, "#{field} items must be strings"}
+  end
+
+  defp optional_context(_value, field),
+    do: {:error, "#{field} must be a string or list of strings"}
+
+  defp optional_map(nil, _field), do: :ok
+  defp optional_map(value, _field) when is_map(value), do: :ok
+  defp optional_map(_value, field), do: {:error, "#{field} must be an object"}
+
+  defp validate_expected(nil), do: :ok
+
+  defp validate_expected(expected) when is_map(expected) do
+    if Enum.all?(expected, fn {type, opts} ->
+         (is_binary(type) or is_atom(type)) and valid_assertion_value?(opts)
+       end) do
+      :ok
+    else
+      {:error, "expected assertions must use string or atom names and valid options"}
+    end
+  end
+
+  defp validate_expected(expected) when is_list(expected) do
+    if Enum.all?(expected, &(is_binary(&1) or is_atom(&1) or valid_assertion_tuple?(&1))) do
+      :ok
+    else
+      {:error, "expected list items must be assertion names or {name, options} tuples"}
+    end
+  end
+
+  defp validate_expected(_expected), do: {:error, "expected must be an object or list"}
+
+  defp valid_assertion_tuple?({type, opts}) when is_atom(type) or is_binary(type),
+    do: valid_assertion_options?(opts)
+
+  defp valid_assertion_tuple?(_item), do: false
+
+  defp valid_assertion_value?(opts) when is_map(opts), do: valid_assertion_options?(opts)
+  defp valid_assertion_value?(_value), do: true
+
+  defp valid_assertion_options?(opts) when is_map(opts) do
+    Enum.all?(Map.keys(opts), &(is_binary(&1) or is_atom(&1)))
+  end
+
+  defp valid_assertion_options?(opts) when is_list(opts), do: Keyword.keyword?(opts)
+  defp valid_assertion_options?(_opts), do: false
+
   defp extract_assertions(item) when is_map(item) do
     expected = item["expected"] || item[:expected] || %{}
     normalize_assertions(expected)
@@ -134,21 +253,27 @@ defmodule Tribunal.Dataset do
   end
 
   defp normalize_type(type) when is_binary(type) do
-    String.to_existing_atom(type)
-  rescue
-    ArgumentError -> type
+    Tribunal.Assertions.resolve_type(type)
   end
 
   defp normalize_type(type) when is_atom(type), do: type
 
   defp normalize_opts(opts) when is_map(opts) do
     Enum.map(opts, fn
-      {k, v} when is_binary(k) -> {existing_atom_or_string(k), v}
+      {k, v} when is_binary(k) -> {normalize_option_key(k), v}
       {k, v} when is_atom(k) -> {k, v}
     end)
   end
 
   defp normalize_opts(opts) when is_list(opts), do: opts
+
+  defp normalize_option_key(value) do
+    Enum.find(@known_option_keys, value, &(Atom.to_string(&1) == value))
+    |> case do
+      ^value -> existing_atom_or_string(value)
+      key -> key
+    end
+  end
 
   defp existing_atom_or_string(value) do
     String.to_existing_atom(value)

--- a/lib/tribunal/eval_case.ex
+++ b/lib/tribunal/eval_case.ex
@@ -136,6 +136,7 @@ defmodule Tribunal.EvalCase.Assertions do
       case Deterministic.evaluate(:contains, output, opts) do
         {:pass, _} -> :ok
         {:fail, details} -> flunk(details[:reason])
+        {:error, reason} -> flunk(reason)
       end
     end
   end
@@ -149,6 +150,7 @@ defmodule Tribunal.EvalCase.Assertions do
       case Deterministic.evaluate(:not_contains, output, opts) do
         {:pass, _} -> :ok
         {:fail, details} -> flunk(details[:reason])
+        {:error, reason} -> flunk(reason)
       end
     end
   end
@@ -162,6 +164,7 @@ defmodule Tribunal.EvalCase.Assertions do
       case Deterministic.evaluate(:contains_any, output, opts) do
         {:pass, _} -> :ok
         {:fail, details} -> flunk(details[:reason])
+        {:error, reason} -> flunk(reason)
       end
     end
   end
@@ -175,6 +178,7 @@ defmodule Tribunal.EvalCase.Assertions do
       case Deterministic.evaluate(:contains_all, output, opts) do
         {:pass, _} -> :ok
         {:fail, details} -> flunk(details[:reason])
+        {:error, reason} -> flunk(reason)
       end
     end
   end

--- a/lib/tribunal/eval_case.ex
+++ b/lib/tribunal/eval_case.ex
@@ -71,19 +71,10 @@ defmodule Tribunal.EvalCase do
           actual_output = apply(module, function, [test_case.input])
           test_case = Tribunal.TestCase.with_output(test_case, actual_output)
 
-          # Run all assertions
-          results = Tribunal.Assertions.evaluate_all(assertions, test_case)
+          result = Tribunal.Evaluator.evaluate(test_case, assertions, defaults: defaults)
 
-          # Fail if any assertion failed
-          failures =
-            results
-            |> Enum.filter(fn {_type, result} -> match?({:fail, _}, result) end)
-            |> Enum.map(fn {type, {:fail, details}} ->
-              "#{type}: #{details[:reason]}"
-            end)
-
-          if failures != [] do
-            flunk(Enum.join(failures, "\n"))
+          if result.status == :failed do
+            flunk(Tribunal.Evaluator.failure_message(result))
           end
         end
       end

--- a/lib/tribunal/evaluator.ex
+++ b/lib/tribunal/evaluator.ex
@@ -41,7 +41,7 @@ defmodule Tribunal.Evaluator do
       actual_output: test_case.actual_output,
       status: if(failures == [], do: :passed, else: :failed),
       failures: failures,
-      results: Map.new(evaluations),
+      results: Assertions.summarize(evaluations),
       evaluations: evaluations,
       duration_ms: now() - started_at
     }
@@ -53,15 +53,17 @@ defmodule Tribunal.Evaluator do
   @spec error(TestCase.t(), term(), keyword()) :: result()
   def error(%TestCase{} = test_case, reason, opts \\ []) do
     started_at = Keyword.get_lazy(opts, :started_at, &now/0)
+    evaluations = scheduled_errors(Keyword.get(opts, :assertions, []), reason)
+    duration_ms = Keyword.get(opts, :duration_ms, now() - started_at)
 
     %{
       input: test_case.input,
       actual_output: test_case.actual_output,
       status: :failed,
       failures: [{:provider, reason(reason, "Provider failed")}],
-      results: %{},
-      evaluations: [],
-      duration_ms: now() - started_at
+      results: Assertions.summarize(evaluations),
+      evaluations: evaluations,
+      duration_ms: duration_ms
     }
   end
 
@@ -70,7 +72,9 @@ defmodule Tribunal.Evaluator do
     Enum.map_join(failures, "\n", fn {type, reason} -> "#{type}: #{reason}" end)
   end
 
-  defp evaluate_assertions(%TestCase{actual_output: nil}, _assertions, _defaults), do: []
+  defp evaluate_assertions(%TestCase{actual_output: nil}, assertions, _defaults) do
+    scheduled_errors(assertions, "Missing actual output")
+  end
 
   defp evaluate_assertions(test_case, assertions, defaults) do
     Assertions.evaluate_each(assertions, test_case, defaults)
@@ -106,6 +110,19 @@ defmodule Tribunal.Evaluator do
   defp reason(reason, _fallback) when is_binary(reason), do: reason
   defp reason(reason, fallback) when is_nil(reason), do: fallback
   defp reason(reason, _fallback), do: inspect(reason)
+
+  defp scheduled_errors(assertions, reason) when is_map(assertions) do
+    assertions
+    |> Map.keys()
+    |> Enum.map(&{&1, {:error, reason}})
+  end
+
+  defp scheduled_errors(assertions, reason) when is_list(assertions) do
+    Enum.map(assertions, fn
+      {type, _opts} -> {type, {:error, reason}}
+      type -> {type, {:error, reason}}
+    end)
+  end
 
   defp now, do: System.monotonic_time(:millisecond)
 end

--- a/lib/tribunal/evaluator.ex
+++ b/lib/tribunal/evaluator.ex
@@ -1,0 +1,111 @@
+defmodule Tribunal.Evaluator do
+  @moduledoc """
+  Evaluates one test case and classifies its outcome.
+
+  This module contains the evaluation semantics shared by the Mix task and
+  `Tribunal.EvalCase`. It does not invoke providers, aggregate a suite, format
+  reports, or interact with ExUnit.
+  """
+
+  alias Tribunal.{Assertions, TestCase}
+
+  @type assertion_result :: {atom() | String.t(), {:pass | :fail, map()} | {:error, term()}}
+
+  @type result :: %{
+          input: term(),
+          actual_output: term(),
+          status: :passed | :failed,
+          failures: [{atom() | String.t(), String.t()}],
+          results: map(),
+          evaluations: [assertion_result()],
+          duration_ms: non_neg_integer()
+        }
+
+  @doc """
+  Evaluates all configured assertions for one populated test case.
+
+  Default options are merged into each assertion, with assertion-specific
+  options taking precedence. Missing output, missing assertions, assertion
+  errors, and unexpected assertion results fail closed.
+  """
+  @spec evaluate(TestCase.t(), list() | map(), keyword()) :: result()
+  def evaluate(%TestCase{} = test_case, assertions, opts \\ []) do
+    started_at = Keyword.get_lazy(opts, :started_at, &now/0)
+    defaults = Keyword.get(opts, :defaults, [])
+
+    evaluations = evaluate_assertions(test_case, assertions, defaults)
+    failures = failures(test_case, assertions, evaluations)
+
+    %{
+      input: test_case.input,
+      actual_output: test_case.actual_output,
+      status: if(failures == [], do: :passed, else: :failed),
+      failures: failures,
+      results: Map.new(evaluations),
+      evaluations: evaluations,
+      duration_ms: now() - started_at
+    }
+  end
+
+  @doc """
+  Builds a failed case result when execution fails before assertions can run.
+  """
+  @spec error(TestCase.t(), term(), keyword()) :: result()
+  def error(%TestCase{} = test_case, reason, opts \\ []) do
+    started_at = Keyword.get_lazy(opts, :started_at, &now/0)
+
+    %{
+      input: test_case.input,
+      actual_output: test_case.actual_output,
+      status: :failed,
+      failures: [{:provider, reason(reason, "Provider failed")}],
+      results: %{},
+      evaluations: [],
+      duration_ms: now() - started_at
+    }
+  end
+
+  @doc false
+  def failure_message(%{failures: failures}) do
+    Enum.map_join(failures, "\n", fn {type, reason} -> "#{type}: #{reason}" end)
+  end
+
+  defp evaluate_assertions(%TestCase{actual_output: nil}, _assertions, _defaults), do: []
+
+  defp evaluate_assertions(test_case, assertions, defaults) do
+    Assertions.evaluate_each(assertions, test_case, defaults)
+  end
+
+  defp failures(%TestCase{actual_output: nil}, _assertions, _evaluations) do
+    [{:evaluation, "Missing actual output"}]
+  end
+
+  defp failures(_test_case, assertions, _evaluations)
+       when assertions == [] or assertions == %{} do
+    [{:evaluation, "No assertions configured"}]
+  end
+
+  defp failures(_test_case, _assertions, evaluations) do
+    Enum.flat_map(evaluations, fn
+      {_type, {:pass, _details}} ->
+        []
+
+      {type, {:fail, details}} ->
+        [{type, reason(details, "Assertion failed")}]
+
+      {type, {:error, error}} ->
+        [{type, reason(error, "Assertion errored")}]
+
+      {type, result} ->
+        [{type, "Unexpected assertion result: #{inspect(result)}"}]
+    end)
+  end
+
+  defp reason(%{reason: reason}, _fallback) when is_binary(reason), do: reason
+  defp reason(details, fallback) when is_map(details), do: Map.get(details, "reason", fallback)
+  defp reason(reason, _fallback) when is_binary(reason), do: reason
+  defp reason(reason, fallback) when is_nil(reason), do: fallback
+  defp reason(reason, _fallback), do: inspect(reason)
+
+  defp now, do: System.monotonic_time(:millisecond)
+end

--- a/lib/tribunal/evaluator.ex
+++ b/lib/tribunal/evaluator.ex
@@ -18,6 +18,7 @@ defmodule Tribunal.Evaluator do
           failures: [{atom() | String.t(), String.t()}],
           results: map(),
           evaluations: [assertion_result()],
+          execution_error: boolean(),
           duration_ms: non_neg_integer()
         }
 
@@ -43,6 +44,7 @@ defmodule Tribunal.Evaluator do
       failures: failures,
       results: Assertions.summarize(evaluations),
       evaluations: evaluations,
+      execution_error: execution_error?(test_case, assertions, evaluations),
       duration_ms: now() - started_at
     }
   end
@@ -63,6 +65,7 @@ defmodule Tribunal.Evaluator do
       failures: [{:provider, reason(reason, "Provider failed")}],
       results: Assertions.summarize(evaluations),
       evaluations: evaluations,
+      execution_error: true,
       duration_ms: duration_ms
     }
   end
@@ -121,6 +124,19 @@ defmodule Tribunal.Evaluator do
     Enum.map(assertions, fn
       {type, _opts} -> {type, {:error, reason}}
       type -> {type, {:error, reason}}
+    end)
+  end
+
+  defp execution_error?(%TestCase{actual_output: nil}, _assertions, _evaluations), do: true
+
+  defp execution_error?(_test_case, assertions, _evaluations) when assertions in [[], %{}],
+    do: true
+
+  defp execution_error?(_test_case, _assertions, evaluations) do
+    Enum.any?(evaluations, fn
+      {_type, {:pass, _details}} -> false
+      {_type, {:fail, _details}} -> false
+      _evaluation -> true
     end)
   end
 

--- a/lib/tribunal/evaluator.ex
+++ b/lib/tribunal/evaluator.ex
@@ -55,14 +55,15 @@ defmodule Tribunal.Evaluator do
   @spec error(TestCase.t(), term(), keyword()) :: result()
   def error(%TestCase{} = test_case, reason, opts \\ []) do
     started_at = Keyword.get_lazy(opts, :started_at, &now/0)
-    evaluations = scheduled_errors(Keyword.get(opts, :assertions, []), reason)
+    failure_reason = reason(reason, "Provider failed")
+    evaluations = scheduled_errors(Keyword.get(opts, :assertions, []), failure_reason)
     duration_ms = Keyword.get(opts, :duration_ms, now() - started_at)
 
     %{
       input: test_case.input,
       actual_output: test_case.actual_output,
       status: :failed,
-      failures: [{:provider, reason(reason, "Provider failed")}],
+      failures: [{:provider, failure_reason}],
       results: Assertions.summarize(evaluations),
       evaluations: evaluations,
       execution_error: true,
@@ -108,11 +109,19 @@ defmodule Tribunal.Evaluator do
     end)
   end
 
-  defp reason(%{reason: reason}, _fallback) when is_binary(reason), do: reason
-  defp reason(details, fallback) when is_map(details), do: Map.get(details, "reason", fallback)
+  defp reason(%{__exception__: true} = exception, _fallback), do: Exception.message(exception)
+  defp reason(%{reason: reason}, fallback), do: normalize_reason(reason, fallback)
+
+  defp reason(details, fallback) when is_map(details),
+    do: normalize_reason(Map.get(details, "reason"), fallback)
+
   defp reason(reason, _fallback) when is_binary(reason), do: reason
   defp reason(reason, fallback) when is_nil(reason), do: fallback
   defp reason(reason, _fallback), do: inspect(reason)
+
+  defp normalize_reason(reason, _fallback) when is_binary(reason), do: reason
+  defp normalize_reason(reason, fallback) when is_nil(reason), do: fallback
+  defp normalize_reason(reason, _fallback), do: inspect(reason)
 
   defp scheduled_errors(assertions, reason) when is_map(assertions) do
     assertions

--- a/lib/tribunal/reporter.ex
+++ b/lib/tribunal/reporter.ex
@@ -114,10 +114,11 @@ defmodule Tribunal.Reporter.Console do
 
   defp footer(summary) do
     status =
-      case Map.get(summary, :threshold_passed, summary.failed == 0) do
-        nil -> "✅ COMPLETED (no gate)"
-        true -> "✅ PASSED"
-        false -> "❌ FAILED"
+      case Map.get(summary, :gate_status) do
+        status when status in [:error, :failed] -> "❌ FAILED"
+        :passed -> "✅ PASSED"
+        :not_configured -> "✅ COMPLETED (no gate)"
+        _ -> legacy_console_status(summary)
       end
 
     threshold_info =
@@ -131,6 +132,14 @@ defmodule Tribunal.Reporter.Console do
     ───────────────────────────────────────────────────────────────
     #{status}#{threshold_info}
     """
+  end
+
+  defp legacy_console_status(summary) do
+    case Map.get(summary, :threshold_passed, summary.failed == 0) do
+      nil -> "✅ COMPLETED (no gate)"
+      true -> "✅ PASSED"
+      false -> "❌ FAILED"
+    end
   end
 
   defp progress_bar(rate, width) do
@@ -244,10 +253,11 @@ defmodule Tribunal.Reporter.Text do
 
   defp footer(summary) do
     status =
-      case Map.get(summary, :threshold_passed, summary.failed == 0) do
-        nil -> "COMPLETED (no gate)"
-        true -> "PASSED"
-        false -> "FAILED"
+      case Map.get(summary, :gate_status) do
+        status when status in [:error, :failed] -> "FAILED"
+        :passed -> "PASSED"
+        :not_configured -> "COMPLETED (no gate)"
+        _ -> legacy_text_status(summary)
       end
 
     threshold_info =
@@ -261,6 +271,14 @@ defmodule Tribunal.Reporter.Text do
     -------------------------------------------------------------------
     #{status}#{threshold_info}
     """
+  end
+
+  defp legacy_text_status(summary) do
+    case Map.get(summary, :threshold_passed, summary.failed == 0) do
+      nil -> "COMPLETED (no gate)"
+      true -> "PASSED"
+      false -> "FAILED"
+    end
   end
 
   defp progress_bar(rate, width) do
@@ -464,10 +482,11 @@ defmodule Tribunal.Reporter.HTML do
 
   defp summary_section(summary) do
     {status_class, status_text} =
-      case Map.get(summary, :threshold_passed, summary.failed == 0) do
-        nil -> {"completed", "COMPLETED (no gate)"}
-        true -> {"passed", "PASSED"}
-        false -> {"failed", "FAILED"}
+      case Map.get(summary, :gate_status) do
+        status when status in [:error, :failed] -> {"failed", "FAILED"}
+        :passed -> {"passed", "PASSED"}
+        :not_configured -> {"completed", "COMPLETED (no gate)"}
+        _ -> legacy_html_status(summary)
       end
 
     threshold_info =
@@ -504,6 +523,14 @@ defmodule Tribunal.Reporter.HTML do
       <div class="status #{status_class}">#{status_text}#{threshold_info}</div>
     </div>
     """
+  end
+
+  defp legacy_html_status(summary) do
+    case Map.get(summary, :threshold_passed, summary.failed == 0) do
+      nil -> {"completed", "COMPLETED (no gate)"}
+      true -> {"passed", "PASSED"}
+      false -> {"failed", "FAILED"}
+    end
   end
 
   defp metrics_section(metrics) when map_size(metrics) == 0, do: ""

--- a/lib/tribunal/reporter.ex
+++ b/lib/tribunal/reporter.ex
@@ -113,9 +113,12 @@ defmodule Tribunal.Reporter.Console do
   end
 
   defp footer(summary) do
-    # Use threshold_passed if available (from mix task), otherwise just check failures
-    passed = Map.get(summary, :threshold_passed, summary.failed == 0)
-    status = if passed, do: "✅ PASSED", else: "❌ FAILED"
+    status =
+      case Map.get(summary, :threshold_passed, summary.failed == 0) do
+        nil -> "✅ COMPLETED (no gate)"
+        true -> "✅ PASSED"
+        false -> "❌ FAILED"
+      end
 
     threshold_info =
       cond do
@@ -240,8 +243,12 @@ defmodule Tribunal.Reporter.Text do
   end
 
   defp footer(summary) do
-    passed = Map.get(summary, :threshold_passed, summary.failed == 0)
-    status = if passed, do: "PASSED", else: "FAILED"
+    status =
+      case Map.get(summary, :threshold_passed, summary.failed == 0) do
+        nil -> "COMPLETED (no gate)"
+        true -> "PASSED"
+        false -> "FAILED"
+      end
 
     threshold_info =
       cond do
@@ -423,6 +430,7 @@ defmodule Tribunal.Reporter.HTML do
         .status { padding: 0.5rem 1rem; border-radius: 4px; display: inline-block; font-weight: bold; margin-top: 1rem; }
         .status.passed { background: #d4edda; color: #155724; }
         .status.failed { background: #f8d7da; color: #721c24; }
+        .status.completed { background: #e2e3e5; color: #383d41; }
         .metrics { background: white; border-radius: 8px; padding: 1.5rem; margin-bottom: 1.5rem; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
         .metrics h2 { margin-bottom: 1rem; color: #333; font-size: 1.2rem; }
         .metric-row { display: flex; align-items: center; margin-bottom: 0.75rem; }
@@ -455,9 +463,12 @@ defmodule Tribunal.Reporter.HTML do
   end
 
   defp summary_section(summary) do
-    passed = Map.get(summary, :threshold_passed, summary.failed == 0)
-    status_class = if passed, do: "passed", else: "failed"
-    status_text = if passed, do: "PASSED", else: "FAILED"
+    {status_class, status_text} =
+      case Map.get(summary, :threshold_passed, summary.failed == 0) do
+        nil -> {"completed", "COMPLETED (no gate)"}
+        true -> {"passed", "PASSED"}
+        false -> {"failed", "FAILED"}
+      end
 
     threshold_info =
       cond do

--- a/lib/tribunal/test_case.ex
+++ b/lib/tribunal/test_case.ex
@@ -88,27 +88,19 @@ defmodule Tribunal.TestCase do
   end
 
   defp normalize_keys(map) do
-    Map.new(map, fn
-      {k, v} when is_binary(k) -> {String.to_existing_atom(k), v}
-      {k, v} when is_atom(k) -> {k, v}
+    fields = MapSet.new(__struct__() |> Map.from_struct() |> Map.keys())
+
+    Enum.reduce(map, %{}, fn
+      {key, value}, acc when is_atom(key) ->
+        if MapSet.member?(fields, key), do: Map.put(acc, key, value), else: acc
+
+      {key, value}, acc when is_binary(key) ->
+        case Enum.find(fields, &(Atom.to_string(&1) == key)) do
+          nil -> acc
+          field -> Map.put(acc, field, value)
+        end
     end)
-  rescue
-    ArgumentError -> Map.new(map, fn {k, v} -> {safe_to_atom(k), v} end)
   end
-
-  defp safe_to_atom(k) when is_binary(k) do
-    case k do
-      "input" -> :input
-      "actual_output" -> :actual_output
-      "expected_output" -> :expected_output
-      "context" -> :context
-      "retrieval_context" -> :retrieval_context
-      "metadata" -> :metadata
-      _ -> String.to_atom(k)
-    end
-  end
-
-  defp safe_to_atom(k) when is_atom(k), do: k
 
   defp normalize_context(nil), do: nil
   defp normalize_context(ctx) when is_binary(ctx), do: [ctx]

--- a/mix.exs
+++ b/mix.exs
@@ -75,7 +75,8 @@ defmodule Tribunal.MixProject do
         Core: [
           Tribunal,
           Tribunal.TestCase,
-          Tribunal.Assertions
+          Tribunal.Assertions,
+          Tribunal.Evaluator
         ],
         "Assertion Types": [
           Tribunal.Assertions.Deterministic,

--- a/test/fixtures/eval_case_dataset.json
+++ b/test/fixtures/eval_case_dataset.json
@@ -1,0 +1,8 @@
+[
+  {
+    "input": "What is the return window?",
+    "expected": {
+      "contains": ["30 days"]
+    }
+  }
+]

--- a/test/mix/tasks/tribunal_eval_integration_test.exs
+++ b/test/mix/tasks/tribunal_eval_integration_test.exs
@@ -18,17 +18,49 @@ defmodule Mix.Tasks.TribunalEvalIntegrationTest do
     Mix.Task.reenable("tribunal.eval")
     Mix.Task.reenable("app.start")
 
-    output = capture_io(fn -> Eval.run([path, "--format", "text"]) end)
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, "Evaluation failed", fn ->
+          Eval.run([path, "--format", "text"])
+        end
+      end)
 
     assert output =~ "Failed:    1"
     assert output =~ "contains"
     assert output =~ "evaluation: Missing actual output"
-    assert output =~ "COMPLETED (no gate)"
-    refute output =~ "\nPASSED"
+    assert output =~ "FAILED"
   end
 
   test "reports a provider exception as a failed case", %{tmp_dir: tmp_dir} do
     path = Path.join(tmp_dir, "provider_error.json")
+
+    File.write!(
+      path,
+      ~s([{"input":"hello","expected":{"contains":["hello"]}}])
+    )
+
+    Mix.Task.reenable("tribunal.eval")
+    Mix.Task.reenable("app.start")
+
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, "Evaluation failed", fn ->
+          Eval.run([
+            path,
+            "--format",
+            "text",
+            "--provider",
+            "Mix.Tasks.TribunalEvalIntegrationTest.failing_provider"
+          ])
+        end
+      end)
+
+    assert output =~ "Failed:    1"
+    assert output =~ "provider: provider exploded"
+  end
+
+  test "keeps ordinary quality failures report-only without a gate", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "quality_failure.json")
 
     File.write!(
       path,
@@ -45,12 +77,12 @@ defmodule Mix.Tasks.TribunalEvalIntegrationTest do
           "--format",
           "text",
           "--provider",
-          "Mix.Tasks.TribunalEvalIntegrationTest.failing_provider"
+          "Mix.Tasks.TribunalEvalIntegrationTest.wrong_provider"
         ])
       end)
 
     assert output =~ "Failed:    1"
-    assert output =~ "provider: provider exploded"
+    assert output =~ "COMPLETED (no gate)"
   end
 
   test "fails when no eval files exist", %{tmp_dir: tmp_dir} do
@@ -96,13 +128,15 @@ defmodule Mix.Tasks.TribunalEvalIntegrationTest do
 
     output =
       capture_io(fn ->
-        Eval.run([
-          path,
-          "--format",
-          "text",
-          "--provider",
-          "Mix.Tasks.TribunalEvalIntegrationTest.killing_provider"
-        ])
+        assert_raise Mix.Error, "Evaluation failed", fn ->
+          Eval.run([
+            path,
+            "--format",
+            "text",
+            "--provider",
+            "Mix.Tasks.TribunalEvalIntegrationTest.killing_provider"
+          ])
+        end
       end)
 
     assert output =~ "Failed:    1"
@@ -144,19 +178,22 @@ defmodule Mix.Tasks.TribunalEvalIntegrationTest do
     Mix.Task.reenable("app.start")
 
     capture_io(fn ->
-      Eval.run([
-        path,
-        "--format",
-        "text",
-        "--concurrency",
-        "2",
-        "--provider",
-        "Mix.Tasks.TribunalEvalIntegrationTest.#{provider}"
-      ])
+      assert_raise Mix.Error, "Evaluation failed", fn ->
+        Eval.run([
+          path,
+          "--format",
+          "text",
+          "--concurrency",
+          "2",
+          "--provider",
+          "Mix.Tasks.TribunalEvalIntegrationTest.#{provider}"
+        ])
+      end
     end)
   end
 
   def failing_provider(_test_case), do: raise("provider exploded")
+  def wrong_provider(_test_case), do: "wrong answer"
 
   def killing_provider(%Tribunal.TestCase{input: "kill"}), do: Process.exit(self(), :kill)
   def killing_provider(%Tribunal.TestCase{input: "pass"}), do: "ok"

--- a/test/mix/tasks/tribunal_eval_integration_test.exs
+++ b/test/mix/tasks/tribunal_eval_integration_test.exs
@@ -1,0 +1,62 @@
+defmodule Mix.Tasks.TribunalEvalIntegrationTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Mix.Tasks.Tribunal.Eval
+
+  @moduletag :tmp_dir
+
+  test "reports a missing output as a failed case", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "missing_output.json")
+
+    File.write!(
+      path,
+      ~s([{"input":"hello","expected":{"contains":["hello"]}}])
+    )
+
+    Mix.Task.reenable("tribunal.eval")
+    Mix.Task.reenable("app.start")
+
+    output = capture_io(fn -> Eval.run([path, "--format", "text"]) end)
+
+    assert output =~ "Failed:    1"
+    assert output =~ "evaluation: Missing actual output"
+  end
+
+  test "reports a provider exception as a failed case", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "provider_error.json")
+
+    File.write!(
+      path,
+      ~s([{"input":"hello","expected":{"contains":["hello"]}}])
+    )
+
+    Mix.Task.reenable("tribunal.eval")
+    Mix.Task.reenable("app.start")
+
+    output =
+      capture_io(fn ->
+        Eval.run([
+          path,
+          "--format",
+          "text",
+          "--provider",
+          "Mix.Tasks.TribunalEvalIntegrationTest.failing_provider"
+        ])
+      end)
+
+    assert output =~ "Failed:    1"
+    assert output =~ "provider: provider exploded"
+  end
+
+  test "fails when no eval files exist", %{tmp_dir: tmp_dir} do
+    File.cd!(tmp_dir, fn ->
+      Mix.Task.reenable("tribunal.eval")
+
+      assert_raise Mix.Error, ~r/No eval files found/, fn -> Eval.run([]) end
+    end)
+  end
+
+  def failing_provider(_test_case), do: raise("provider exploded")
+end

--- a/test/mix/tasks/tribunal_eval_integration_test.exs
+++ b/test/mix/tasks/tribunal_eval_integration_test.exs
@@ -59,6 +59,27 @@ defmodule Mix.Tasks.TribunalEvalIntegrationTest do
     assert output =~ "provider: provider exploded"
   end
 
+  test "leaves threshold result unset for an ungated operational error", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "missing_output.json")
+    report_path = Path.join(tmp_dir, "report.json")
+
+    File.write!(path, ~s([{"input":"hello","expected":{"contains":["hello"]}}]))
+
+    Mix.Task.reenable("tribunal.eval")
+    Mix.Task.reenable("app.start")
+
+    capture_io(fn ->
+      assert_raise Mix.Error, "Evaluation failed", fn ->
+        Eval.run([path, "--format", "json", "--output", report_path])
+      end
+    end)
+
+    report = report_path |> File.read!() |> JSON.decode!()
+
+    assert report["summary"]["gate_status"] == "error"
+    assert report["summary"]["threshold_passed"] == nil
+  end
+
   test "keeps ordinary quality failures report-only without a gate", %{tmp_dir: tmp_dir} do
     path = Path.join(tmp_dir, "quality_failure.json")
 
@@ -91,6 +112,46 @@ defmodule Mix.Tasks.TribunalEvalIntegrationTest do
 
       assert_raise Mix.Error, ~r/No eval files found/, fn -> Eval.run([]) end
     end)
+  end
+
+  test "fails when a dataset contains no cases", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "empty.json")
+    File.write!(path, "[]")
+
+    Mix.Task.reenable("tribunal.eval")
+    Mix.Task.reenable("app.start")
+
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, "Evaluation failed", fn ->
+          Eval.run([path, "--format", "text"])
+        end
+      end)
+
+    assert output =~ "Total:     0 test cases"
+    assert output =~ "FAILED"
+  end
+
+  test "fails when offset skips every case", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "offset.json")
+
+    File.write!(
+      path,
+      ~s([{"input":"hello","actual_output":"hello","expected":{"contains":["hello"]}}])
+    )
+
+    Mix.Task.reenable("tribunal.eval")
+    Mix.Task.reenable("app.start")
+
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, "Evaluation failed", fn ->
+          Eval.run([path, "--format", "text", "--offset", "1"])
+        end
+      end)
+
+    assert output =~ "Total:     0 test cases"
+    assert output =~ "FAILED"
   end
 
   @tag capture_log: true
@@ -156,13 +217,13 @@ defmodule Mix.Tasks.TribunalEvalIntegrationTest do
     )
 
     previous_timeout = Application.get_env(:tribunal, :eval_timeout)
-    Application.put_env(:tribunal, :eval_timeout, 10)
+    Application.put_env(:tribunal, :eval_timeout, 50)
 
     on_exit(fn ->
-      if previous_timeout do
-        Application.put_env(:tribunal, :eval_timeout, previous_timeout)
-      else
+      if is_nil(previous_timeout) do
         Application.delete_env(:tribunal, :eval_timeout)
+      else
+        Application.put_env(:tribunal, :eval_timeout, previous_timeout)
       end
     end)
 
@@ -199,7 +260,7 @@ defmodule Mix.Tasks.TribunalEvalIntegrationTest do
   def killing_provider(%Tribunal.TestCase{input: "pass"}), do: "ok"
 
   def slow_provider(%Tribunal.TestCase{input: "slow"}) do
-    Process.sleep(100)
+    Process.sleep(500)
     "ok"
   end
 

--- a/test/mix/tasks/tribunal_eval_integration_test.exs
+++ b/test/mix/tasks/tribunal_eval_integration_test.exs
@@ -21,7 +21,10 @@ defmodule Mix.Tasks.TribunalEvalIntegrationTest do
     output = capture_io(fn -> Eval.run([path, "--format", "text"]) end)
 
     assert output =~ "Failed:    1"
+    assert output =~ "contains"
     assert output =~ "evaluation: Missing actual output"
+    assert output =~ "COMPLETED (no gate)"
+    refute output =~ "\nPASSED"
   end
 
   test "reports a provider exception as a failed case", %{tmp_dir: tmp_dir} do
@@ -58,5 +61,110 @@ defmodule Mix.Tasks.TribunalEvalIntegrationTest do
     end)
   end
 
+  @tag capture_log: true
+  test "reports a killed concurrent provider without killing the run", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "killed_provider.json")
+
+    File.write!(
+      path,
+      JSON.encode!([
+        %{"input" => "kill", "expected" => %{"contains" => ["ok"]}},
+        %{"input" => "pass", "expected" => %{"contains" => ["ok"]}}
+      ])
+    )
+
+    output = run_eval(path, "killing_provider")
+
+    assert output =~ "Passed:    1"
+    assert output =~ "Failed:    1"
+    assert output =~ "Evaluation task failed"
+  end
+
+  @tag capture_log: true
+  test "isolates a killed provider with default concurrency", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "killed_sequential_provider.json")
+
+    File.write!(
+      path,
+      JSON.encode!([
+        %{"input" => "kill", "expected" => %{"contains" => ["ok"]}}
+      ])
+    )
+
+    Mix.Task.reenable("tribunal.eval")
+    Mix.Task.reenable("app.start")
+
+    output =
+      capture_io(fn ->
+        Eval.run([
+          path,
+          "--format",
+          "text",
+          "--provider",
+          "Mix.Tasks.TribunalEvalIntegrationTest.killing_provider"
+        ])
+      end)
+
+    assert output =~ "Failed:    1"
+    assert output =~ "Evaluation task failed"
+  end
+
+  @tag capture_log: true
+  test "reports a concurrent provider timeout", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "timeout_provider.json")
+
+    File.write!(
+      path,
+      JSON.encode!([
+        %{"input" => "slow", "expected" => %{"contains" => ["ok"]}},
+        %{"input" => "pass", "expected" => %{"contains" => ["ok"]}}
+      ])
+    )
+
+    previous_timeout = Application.get_env(:tribunal, :eval_timeout)
+    Application.put_env(:tribunal, :eval_timeout, 10)
+
+    on_exit(fn ->
+      if previous_timeout do
+        Application.put_env(:tribunal, :eval_timeout, previous_timeout)
+      else
+        Application.delete_env(:tribunal, :eval_timeout)
+      end
+    end)
+
+    output = run_eval(path, "slow_provider")
+
+    assert output =~ "Passed:    1"
+    assert output =~ "Failed:    1"
+    assert output =~ "Evaluation task failed: :timeout"
+  end
+
+  defp run_eval(path, provider) do
+    Mix.Task.reenable("tribunal.eval")
+    Mix.Task.reenable("app.start")
+
+    capture_io(fn ->
+      Eval.run([
+        path,
+        "--format",
+        "text",
+        "--concurrency",
+        "2",
+        "--provider",
+        "Mix.Tasks.TribunalEvalIntegrationTest.#{provider}"
+      ])
+    end)
+  end
+
   def failing_provider(_test_case), do: raise("provider exploded")
+
+  def killing_provider(%Tribunal.TestCase{input: "kill"}), do: Process.exit(self(), :kill)
+  def killing_provider(%Tribunal.TestCase{input: "pass"}), do: "ok"
+
+  def slow_provider(%Tribunal.TestCase{input: "slow"}) do
+    Process.sleep(100)
+    "ok"
+  end
+
+  def slow_provider(%Tribunal.TestCase{input: "pass"}), do: "ok"
 end

--- a/test/mix/tasks/tribunal_redteam_generate_test.exs
+++ b/test/mix/tasks/tribunal_redteam_generate_test.exs
@@ -1,0 +1,23 @@
+defmodule Mix.Tasks.TribunalRedteamGenerateTest do
+  use ExUnit.Case, async: false
+
+  alias Mix.Tasks.Tribunal.Redteam.Generate
+
+  test "rejects unknown plugins without creating atoms" do
+    plugin = "unknown_#{System.unique_integer([:positive])}"
+    refute existing_atom?(plugin)
+
+    assert_raise Mix.Error, ~r/Unknown red-team plugin/, fn ->
+      Generate.run(["--plugins", plugin, "--purpose", "test"])
+    end
+
+    refute existing_atom?(plugin)
+  end
+
+  defp existing_atom?(value) do
+    _atom = String.to_existing_atom(value)
+    true
+  rescue
+    ArgumentError -> false
+  end
+end

--- a/test/mix/tasks/tribunal_test.exs
+++ b/test/mix/tasks/tribunal_test.exs
@@ -57,6 +57,20 @@ defmodule Mix.Tasks.TribunalTest do
       behaviours = Eval.__info__(:attributes)[:behaviour] || []
       assert Mix.Task in behaviours
     end
+
+    test "rejects unknown options" do
+      assert_raise Mix.Error, ~r/Invalid options/, fn -> Eval.run(["--unknown"]) end
+    end
+
+    test "validates numeric options" do
+      assert_raise Mix.Error, ~r/threshold must be between/, fn ->
+        Eval.run(["--threshold", "1.1"])
+      end
+
+      assert_raise Mix.Error, ~r/concurrency must be at least/, fn ->
+        Eval.run(["--concurrency", "0"])
+      end
+    end
   end
 
   describe "Init" do

--- a/test/mix/tasks/tribunal_test.exs
+++ b/test/mix/tasks/tribunal_test.exs
@@ -71,6 +71,10 @@ defmodule Mix.Tasks.TribunalTest do
         Eval.run(["--concurrency", "0"])
       end
     end
+
+    test "rejects unknown formats before running a dataset" do
+      assert_raise Mix.Error, ~r/Unknown format/, fn -> Eval.run(["--format", "xml"]) end
+    end
   end
 
   describe "Init" do

--- a/test/tribunal/assertions/deterministic_test.exs
+++ b/test/tribunal/assertions/deterministic_test.exs
@@ -23,6 +23,11 @@ defmodule Tribunal.Assertions.DeterministicTest do
       {:fail, details} = Deterministic.evaluate(:contains, "Hello", value: "world")
       assert details.reason =~ "missing"
     end
+
+    test "errors when no expected values are configured" do
+      assert {:error, reason} = Deterministic.evaluate(:contains, "Hello", actual_output: "x")
+      assert reason =~ "requires"
+    end
   end
 
   describe "not_contains" do
@@ -33,6 +38,11 @@ defmodule Tribunal.Assertions.DeterministicTest do
     test "fails when substring found" do
       assert {:fail, %{found: ["world"]}} =
                Deterministic.evaluate(:not_contains, "Hello world", value: "world")
+    end
+
+    test "errors when no forbidden values are configured" do
+      assert {:error, reason} = Deterministic.evaluate(:not_contains, "Hello", [])
+      assert reason =~ "requires"
     end
   end
 
@@ -57,6 +67,11 @@ defmodule Tribunal.Assertions.DeterministicTest do
     test "fails when some missing" do
       assert {:fail, %{missing: ["foo"]}} =
                Deterministic.evaluate(:contains_all, "Hello world", values: ["Hello", "foo"])
+    end
+
+    test "errors when no expected values are configured" do
+      assert {:error, reason} = Deterministic.evaluate(:contains_all, "Hello", [])
+      assert reason =~ "requires"
     end
   end
 

--- a/test/tribunal/assertions/deterministic_test.exs
+++ b/test/tribunal/assertions/deterministic_test.exs
@@ -56,6 +56,11 @@ defmodule Tribunal.Assertions.DeterministicTest do
       assert {:fail, _} =
                Deterministic.evaluate(:contains_any, "Hello world", values: ["foo", "bar"])
     end
+
+    test "errors when no expected values are configured" do
+      assert {:error, reason} = Deterministic.evaluate(:contains_any, "Hello", [])
+      assert reason =~ "requires"
+    end
   end
 
   describe "contains_all" do

--- a/test/tribunal/assertions/judge_test.exs
+++ b/test/tribunal/assertions/judge_test.exs
@@ -233,6 +233,18 @@ defmodule Tribunal.Assertions.JudgeTest do
                Judge.evaluate(:relevant, test_case, model: "openai:gpt-4o", llm: client)
     end
 
+    test "uses the supported default judge model" do
+      test_case = %TestCase{input: "Test", actual_output: "Output"}
+
+      client = fn model, _messages, _opts ->
+        send(self(), {:model, model})
+        {:ok, %{"verdict" => "yes", "reason" => "Relevant"}}
+      end
+
+      assert {:pass, _} = Judge.evaluate(:relevant, test_case, llm: client)
+      assert_received {:model, "anthropic:claude-haiku-4-5-20251001"}
+    end
+
     test "uses threshold option for scoring" do
       test_case = %TestCase{
         input: "Test",
@@ -251,6 +263,25 @@ defmodule Tribunal.Assertions.JudgeTest do
 
       # With lower threshold, should pass
       assert {:pass, _} = Judge.evaluate(:faithful, test_case, threshold: 0.6, llm: client)
+    end
+
+    test "treats a negative metric threshold as the maximum allowed severity" do
+      test_case = %TestCase{input: "Test", actual_output: "Output"}
+
+      low_severity =
+        mock_client({:ok, %{"verdict" => "partial", "score" => 0.2, "reason" => "Mild toxicity"}})
+
+      high_severity =
+        mock_client(
+          {:ok, %{"verdict" => "partial", "score" => 0.9, "reason" => "Severe toxicity"}}
+        )
+
+      boundary =
+        mock_client({:ok, %{"verdict" => "partial", "score" => 0.8, "reason" => "At threshold"}})
+
+      assert {:pass, _} = Judge.evaluate(:toxicity, test_case, threshold: 0.8, llm: low_severity)
+      assert {:pass, _} = Judge.evaluate(:toxicity, test_case, threshold: 0.8, llm: boundary)
+      assert {:fail, _} = Judge.evaluate(:toxicity, test_case, threshold: 0.8, llm: high_severity)
     end
   end
 

--- a/test/tribunal/assertions_test.exs
+++ b/test/tribunal/assertions_test.exs
@@ -28,6 +28,29 @@ defmodule Tribunal.AssertionsTest do
       assert {:error, msg} = Assertions.evaluate(:unknown_assertion, test_case, [])
       assert msg =~ "Unknown assertion"
     end
+
+    test "rejects options that belong to another assertion" do
+      test_case = %TestCase{input: "test", actual_output: "short"}
+
+      assert {:error, reason} =
+               Assertions.evaluate(:max_tokens, test_case, actual_output: 1)
+
+      assert reason =~ "Unknown options for max_tokens"
+    end
+
+    test "accepts documented judge context options" do
+      client = fn _model, _messages, _opts ->
+        {:ok, %{"verdict" => "yes", "reason" => "grounded", "score" => 1.0}}
+      end
+
+      test_case = %TestCase{actual_output: "answer", context: "source"}
+
+      assert {:pass, _} =
+               Assertions.evaluate(:faithful, test_case,
+                 context: "source",
+                 llm_client: client
+               )
+    end
   end
 
   describe "evaluate_all/2" do
@@ -76,6 +99,21 @@ defmodule Tribunal.AssertionsTest do
 
       assert {:pass, _} = results[:is_json]
     end
+
+    test "keeps the worst result for repeated assertion types" do
+      test_case = %TestCase{input: "test", actual_output: "Hello world"}
+
+      results =
+        Assertions.evaluate_all(
+          [
+            {:contains, [value: "missing"]},
+            {:contains, [value: "Hello"]}
+          ],
+          test_case
+        )
+
+      assert {:fail, _} = results[:contains]
+    end
   end
 
   describe "evaluate_each/3" do
@@ -112,6 +150,10 @@ defmodule Tribunal.AssertionsTest do
       }
 
       refute Assertions.all_passed?(results)
+    end
+
+    test "returns false when nothing was evaluated" do
+      refute Assertions.all_passed?(%{})
     end
   end
 

--- a/test/tribunal/assertions_test.exs
+++ b/test/tribunal/assertions_test.exs
@@ -131,6 +131,13 @@ defmodule Tribunal.AssertionsTest do
 
       assert [{:contains, {:pass, _}}, {:contains, {:fail, _}}] = results
     end
+
+    test "returns an error for non-keyword assertion options" do
+      test_case = %TestCase{input: "test", actual_output: "Hello world"}
+
+      assert [contains: {:error, "Assertion options must be a keyword list"}] =
+               Assertions.evaluate_each([{:contains, 42}], test_case)
+    end
   end
 
   describe "all_passed?/1" do

--- a/test/tribunal/assertions_test.exs
+++ b/test/tribunal/assertions_test.exs
@@ -78,6 +78,23 @@ defmodule Tribunal.AssertionsTest do
     end
   end
 
+  describe "evaluate_each/3" do
+    test "preserves repeated assertion types" do
+      test_case = %TestCase{input: "test", actual_output: "Hello world"}
+
+      results =
+        Assertions.evaluate_each(
+          [
+            {:contains, [value: "Hello"]},
+            {:contains, [value: "missing"]}
+          ],
+          test_case
+        )
+
+      assert [{:contains, {:pass, _}}, {:contains, {:fail, _}}] = results
+    end
+  end
+
   describe "all_passed?/1" do
     test "returns true when all pass" do
       results = %{

--- a/test/tribunal/dataset_test.exs
+++ b/test/tribunal/dataset_test.exs
@@ -78,6 +78,57 @@ defmodule Tribunal.DatasetTest do
       File.write!(Path.join(fixtures_path, "test.txt"), "hello")
       assert {:error, _} = Dataset.load(Path.join(fixtures_path, "test.txt"))
     end
+
+    test "returns errors for structurally invalid datasets", %{fixtures_path: fixtures_path} do
+      top_level = Path.join(fixtures_path, "top_level_object.json")
+      invalid_case = Path.join(fixtures_path, "invalid_case.json")
+      missing_input = Path.join(fixtures_path, "missing_input.json")
+      invalid_expected = Path.join(fixtures_path, "invalid_expected.json")
+      invalid_expected_list = Path.join(fixtures_path, "invalid_expected_list.json")
+      invalid_context = Path.join(fixtures_path, "invalid_context.json")
+      invalid_input = Path.join(fixtures_path, "invalid_input.json")
+      invalid_options = Path.join(fixtures_path, "invalid_options.yaml")
+      invalid_case_keys = Path.join(fixtures_path, "invalid_case_keys.yaml")
+
+      File.write!(top_level, JSON.encode!(%{"input" => "hello"}))
+      File.write!(invalid_case, JSON.encode!([42]))
+      File.write!(missing_input, JSON.encode!([%{"expected" => %{}}]))
+      File.write!(invalid_expected, JSON.encode!([%{"input" => "hello", "expected" => 42}]))
+
+      File.write!(
+        invalid_expected_list,
+        JSON.encode!([%{"input" => "hello", "expected" => [%{"contains" => "x"}]}])
+      )
+
+      File.write!(invalid_context, JSON.encode!([%{"input" => "hello", "context" => 42}]))
+      File.write!(invalid_input, JSON.encode!([%{"input" => 42}]))
+
+      File.write!(invalid_options, "- input: hello\n  expected:\n    contains:\n      1: hello\n")
+      File.write!(invalid_case_keys, "- input: hello\n  1: ignored\n")
+
+      assert {:error, {:invalid_dataset, _}} = Dataset.load(top_level)
+      assert {:error, {:invalid_case, 0, "case must be an object"}} = Dataset.load(invalid_case)
+      assert {:error, {:invalid_case, 0, "input is required"}} = Dataset.load(missing_input)
+
+      assert {:error, {:invalid_case, 0, "expected must be an object or list"}} =
+               Dataset.load(invalid_expected)
+
+      assert {:error, {:invalid_case, 0, "expected list items must be assertion names" <> _}} =
+               Dataset.load(invalid_expected_list)
+
+      assert {:error, {:invalid_case, 0, "context must be a string or list of strings"}} =
+               Dataset.load(invalid_context)
+
+      assert {:error, {:invalid_case, 0, "input must be a string"}} = Dataset.load(invalid_input)
+
+      assert {:error,
+              {:invalid_case, 0,
+               "expected assertions must use string or atom names and valid options"}} =
+               Dataset.load(invalid_options)
+
+      assert {:error, {:invalid_case, 0, "case field names must be strings or atoms"}} =
+               Dataset.load(invalid_case_keys)
+    end
   end
 
   describe "load!/1" do
@@ -118,6 +169,54 @@ defmodule Tribunal.DatasetTest do
       assert {:ok, [{_test_case, [{^name, []}]}]} = Dataset.load_with_assertions(path)
       refute existing_atom?(name)
     end
+
+    test "resolves registered custom judge names", %{fixtures_path: fixtures_path} do
+      path = Path.join(fixtures_path, "custom_judge.json")
+
+      File.write!(
+        path,
+        JSON.encode!([
+          %{
+            "input" => "hello",
+            "expected" => %{"dataset_custom_judge" => %{"rules" => "be concise"}}
+          }
+        ])
+      )
+
+      previous = Application.get_env(:tribunal, :custom_judges, [])
+      Application.put_env(:tribunal, :custom_judges, [Tribunal.DatasetCustomJudge])
+      on_exit(fn -> Application.put_env(:tribunal, :custom_judges, previous) end)
+
+      assert {:ok, [{_test_case, [{:dataset_custom_judge, [rules: "be concise"]}]}]} =
+               Dataset.load_with_assertions(path)
+    end
+
+    test "resolves built-in judge option keys explicitly", %{fixtures_path: fixtures_path} do
+      path = Path.join(fixtures_path, "judge_options.json")
+
+      File.write!(
+        path,
+        JSON.encode!([
+          %{
+            "input" => "hello",
+            "expected" => %{
+              "faithful" => %{
+                "model" => "anthropic:claude-haiku-4-5-20251001",
+                "threshold" => 0.9
+              }
+            }
+          }
+        ])
+      )
+
+      assert {:ok,
+              [
+                {_test_case,
+                 [
+                   {:faithful, [model: "anthropic:claude-haiku-4-5-20251001", threshold: 0.9]}
+                 ]}
+              ]} = Dataset.load_with_assertions(path)
+    end
   end
 
   defp existing_atom?(value) do
@@ -126,4 +225,14 @@ defmodule Tribunal.DatasetTest do
   rescue
     ArgumentError -> false
   end
+end
+
+defmodule Tribunal.DatasetCustomJudge do
+  @behaviour Tribunal.Judge
+
+  @impl true
+  def name, do: :dataset_custom_judge
+
+  @impl true
+  def prompt(_test_case, opts), do: Keyword.fetch!(opts, :rules)
 end

--- a/test/tribunal/dataset_test.exs
+++ b/test/tribunal/dataset_test.exs
@@ -108,5 +108,22 @@ defmodule Tribunal.DatasetTest do
       assert :contains_any in types
       assert :not_contains in types
     end
+
+    test "does not create atoms for unknown assertion names", %{fixtures_path: fixtures_path} do
+      name = "unknown_#{System.unique_integer([:positive])}"
+      path = Path.join(fixtures_path, "unknown_assertion.json")
+      File.write!(path, JSON.encode!([%{"input" => "hello", "expected" => %{name => %{}}}]))
+
+      refute existing_atom?(name)
+      assert {:ok, [{_test_case, [{^name, []}]}]} = Dataset.load_with_assertions(path)
+      refute existing_atom?(name)
+    end
+  end
+
+  defp existing_atom?(value) do
+    _atom = String.to_existing_atom(value)
+    true
+  rescue
+    ArgumentError -> false
   end
 end

--- a/test/tribunal/eval_case_test.exs
+++ b/test/tribunal/eval_case_test.exs
@@ -22,6 +22,15 @@ defmodule Tribunal.EvalCaseTest do
         assert_contains("Hello world", "foo")
       end
     end
+
+    test "reports invalid configuration as an assertion failure" do
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_contains("Hello world", [])
+        end
+
+      assert Exception.message(error) =~ "contains requires :value or :values"
+    end
   end
 
   describe "refute_contains/2" do
@@ -33,6 +42,15 @@ defmodule Tribunal.EvalCaseTest do
       assert_raise ExUnit.AssertionError, fn ->
         refute_contains("Hello world", "world")
       end
+    end
+
+    test "reports invalid configuration as an assertion failure" do
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          refute_contains("Hello world", [])
+        end
+
+      assert Exception.message(error) =~ "not_contains requires :value or :values"
     end
   end
 
@@ -46,6 +64,15 @@ defmodule Tribunal.EvalCaseTest do
         assert_contains_any("Hello world", ["foo", "bar"])
       end
     end
+
+    test "reports invalid configuration as an assertion failure" do
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_contains_any("Hello world", [])
+        end
+
+      assert Exception.message(error) =~ "contains_any requires :value or :values"
+    end
   end
 
   describe "assert_contains_all/2" do
@@ -57,6 +84,15 @@ defmodule Tribunal.EvalCaseTest do
       assert_raise ExUnit.AssertionError, fn ->
         assert_contains_all("Hello world", ["Hello", "foo"])
       end
+    end
+
+    test "reports invalid configuration as an assertion failure" do
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_contains_all("Hello world", [])
+        end
+
+      assert Exception.message(error) =~ "contains_all requires :value or :values"
     end
   end
 

--- a/test/tribunal/eval_case_test.exs
+++ b/test/tribunal/eval_case_test.exs
@@ -647,3 +647,16 @@ defmodule Tribunal.EvalCaseTest do
     end
   end
 end
+
+defmodule Tribunal.EvalCaseDatasetProvider do
+  def query("What is the return window?"), do: "Returns are accepted within 30 days."
+end
+
+defmodule Tribunal.EvalCaseGeneratedTest do
+  use ExUnit.Case, async: true
+  use Tribunal.EvalCase
+
+  tribunal_eval(Path.expand("../fixtures/eval_case_dataset.json", __DIR__),
+    provider: {Tribunal.EvalCaseDatasetProvider, :query}
+  )
+end

--- a/test/tribunal/evaluator_test.exs
+++ b/test/tribunal/evaluator_test.exs
@@ -2,6 +2,7 @@ defmodule Tribunal.EvaluatorTest do
   use ExUnit.Case, async: true
 
   alias Tribunal.{Evaluator, TestCase}
+  alias Tribunal.Reporter.JSON, as: JSONReporter
 
   test "passes when every assertion passes" do
     test_case = %TestCase{input: "hello", actual_output: "hello world"}
@@ -116,5 +117,27 @@ defmodule Tribunal.EvaluatorTest do
     result = Evaluator.error(test_case, "timeout", duration_ms: 120_000)
 
     assert result.duration_ms == 120_000
+  end
+
+  test "preserves exception messages in execution failures" do
+    test_case = %TestCase{input: "hello"}
+
+    result =
+      Evaluator.error(test_case, RuntimeError.exception("provider exploded"),
+        assertions: [{:contains, [value: "hello"]}]
+      )
+
+    assert result.failures == [{:provider, "provider exploded"}]
+    assert result.evaluations == [{:contains, {:error, "provider exploded"}}]
+    assert JSONReporter.format(%{cases: [result]}) =~ "provider exploded"
+  end
+
+  test "formats non-string reason values safely" do
+    test_case = %TestCase{input: "hello"}
+
+    result = Evaluator.error(test_case, %{"reason" => %{code: 7}})
+
+    assert result.failures == [{:provider, "%{code: 7}"}]
+    assert Evaluator.failure_message(result) == "provider: %{code: 7}"
   end
 end

--- a/test/tribunal/evaluator_test.exs
+++ b/test/tribunal/evaluator_test.exs
@@ -1,0 +1,87 @@
+defmodule Tribunal.EvaluatorTest do
+  use ExUnit.Case, async: true
+
+  alias Tribunal.{Evaluator, TestCase}
+
+  test "passes when every assertion passes" do
+    test_case = %TestCase{input: "hello", actual_output: "hello world"}
+
+    result =
+      Evaluator.evaluate(test_case, [
+        {:contains, [value: "hello"]},
+        {:not_contains, [value: "goodbye"]}
+      ])
+
+    assert result.status == :passed
+    assert result.failures == []
+  end
+
+  test "fails when actual output is missing" do
+    test_case = %TestCase{input: "hello"}
+
+    result = Evaluator.evaluate(test_case, [{:contains, [value: "hello"]}])
+
+    assert result.status == :failed
+    assert result.failures == [{:evaluation, "Missing actual output"}]
+  end
+
+  test "fails when no assertions are configured" do
+    test_case = %TestCase{input: "hello", actual_output: "hello world"}
+
+    result = Evaluator.evaluate(test_case, [])
+
+    assert result.status == :failed
+    assert result.failures == [{:evaluation, "No assertions configured"}]
+  end
+
+  test "treats assertion errors as failures" do
+    test_case = %TestCase{input: "hello", actual_output: "hello world"}
+
+    result = Evaluator.evaluate(test_case, [:unknown_assertion])
+
+    assert result.status == :failed
+    assert result.failures == [{:unknown_assertion, "Unknown assertion type: unknown_assertion"}]
+  end
+
+  test "preserves repeated assertion results and failures" do
+    test_case = %TestCase{input: "hello", actual_output: "hello world"}
+
+    result =
+      Evaluator.evaluate(test_case, [
+        {:contains, [value: "hello"]},
+        {:contains, [value: "goodbye"]}
+      ])
+
+    assert length(result.evaluations) == 2
+    assert result.status == :failed
+    assert [{:contains, _reason}] = result.failures
+  end
+
+  test "assertion options override defaults" do
+    llm = fn model, _messages, _opts ->
+      send(self(), {:model, model})
+      {:ok, %{"verdict" => "yes", "reason" => "relevant", "score" => 1.0}}
+    end
+
+    test_case = %TestCase{input: "hello", actual_output: "hello world"}
+
+    result =
+      Evaluator.evaluate(
+        test_case,
+        [{:relevant, [model: "case-model", llm: llm]}],
+        defaults: [model: "default-model"]
+      )
+
+    assert result.status == :passed
+    assert_received {:model, "case-model"}
+  end
+
+  test "represents provider failures as failed cases" do
+    test_case = %TestCase{input: "hello"}
+
+    result = Evaluator.error(test_case, "connection refused")
+
+    assert result.status == :failed
+    assert result.failures == [{:provider, "connection refused"}]
+  end
+end

--- a/test/tribunal/evaluator_test.exs
+++ b/test/tribunal/evaluator_test.exs
@@ -23,6 +23,7 @@ defmodule Tribunal.EvaluatorTest do
 
     assert result.status == :failed
     assert result.failures == [{:evaluation, "Missing actual output"}]
+    assert [{:contains, {:error, "Missing actual output"}}] = result.evaluations
   end
 
   test "fails when no assertions are configured" do
@@ -55,6 +56,20 @@ defmodule Tribunal.EvaluatorTest do
     assert length(result.evaluations) == 2
     assert result.status == :failed
     assert [{:contains, _reason}] = result.failures
+    assert {:fail, _} = result.results.contains
+  end
+
+  test "the compatibility result stays failed when a later duplicate passes" do
+    test_case = %TestCase{input: "hello", actual_output: "hello world"}
+
+    result =
+      Evaluator.evaluate(test_case, [
+        {:contains, [value: "goodbye"]},
+        {:contains, [value: "hello"]}
+      ])
+
+    assert result.status == :failed
+    assert {:fail, _} = result.results.contains
   end
 
   test "assertion options override defaults" do
@@ -79,9 +94,21 @@ defmodule Tribunal.EvaluatorTest do
   test "represents provider failures as failed cases" do
     test_case = %TestCase{input: "hello"}
 
-    result = Evaluator.error(test_case, "connection refused")
+    result =
+      Evaluator.error(test_case, "connection refused",
+        assertions: [{:contains, [value: "hello"]}]
+      )
 
     assert result.status == :failed
     assert result.failures == [{:provider, "connection refused"}]
+    assert [{:contains, {:error, "connection refused"}}] = result.evaluations
+  end
+
+  test "preserves an explicit execution duration for task failures" do
+    test_case = %TestCase{input: "hello"}
+
+    result = Evaluator.error(test_case, "timeout", duration_ms: 120_000)
+
+    assert result.duration_ms == 120_000
   end
 end

--- a/test/tribunal/evaluator_test.exs
+++ b/test/tribunal/evaluator_test.exs
@@ -14,6 +14,7 @@ defmodule Tribunal.EvaluatorTest do
 
     assert result.status == :passed
     assert result.failures == []
+    refute result.execution_error
   end
 
   test "fails when actual output is missing" do
@@ -24,6 +25,7 @@ defmodule Tribunal.EvaluatorTest do
     assert result.status == :failed
     assert result.failures == [{:evaluation, "Missing actual output"}]
     assert [{:contains, {:error, "Missing actual output"}}] = result.evaluations
+    assert result.execution_error
   end
 
   test "fails when no assertions are configured" do
@@ -33,6 +35,7 @@ defmodule Tribunal.EvaluatorTest do
 
     assert result.status == :failed
     assert result.failures == [{:evaluation, "No assertions configured"}]
+    assert result.execution_error
   end
 
   test "treats assertion errors as failures" do
@@ -42,6 +45,7 @@ defmodule Tribunal.EvaluatorTest do
 
     assert result.status == :failed
     assert result.failures == [{:unknown_assertion, "Unknown assertion type: unknown_assertion"}]
+    assert result.execution_error
   end
 
   test "preserves repeated assertion results and failures" do
@@ -57,6 +61,7 @@ defmodule Tribunal.EvaluatorTest do
     assert result.status == :failed
     assert [{:contains, _reason}] = result.failures
     assert {:fail, _} = result.results.contains
+    refute result.execution_error
   end
 
   test "the compatibility result stays failed when a later duplicate passes" do
@@ -102,6 +107,7 @@ defmodule Tribunal.EvaluatorTest do
     assert result.status == :failed
     assert result.failures == [{:provider, "connection refused"}]
     assert [{:contains, {:error, "connection refused"}}] = result.evaluations
+    assert result.execution_error
   end
 
   test "preserves an explicit execution duration for task failures" do

--- a/test/tribunal/reporter_test.exs
+++ b/test/tribunal/reporter_test.exs
@@ -84,6 +84,15 @@ defmodule Tribunal.ReporterTest do
       assert output =~ "PASSED"
     end
 
+    test "distinguishes a report-only run from a passed gate" do
+      results = put_in(@sample_results, [:summary, :threshold_passed], nil)
+
+      output = Console.format(results)
+
+      assert output =~ "COMPLETED (no gate)"
+      refute output =~ "PASSED"
+    end
+
     test "aligns metric bars across rows" do
       results = %{
         @sample_results
@@ -147,6 +156,14 @@ defmodule Tribunal.ReporterTest do
       output = JSON.format(@sample_results)
       {:ok, parsed} = json_decode(output)
       assert length(parsed["cases"]) == 3
+    end
+
+    test "documents the emitted failure tuple shape" do
+      output = JSON.format(@sample_results)
+      {:ok, parsed} = json_decode(output)
+
+      assert %{"faithful" => "Score 0.5 below threshold 0.8"} =
+               get_in(parsed, ["cases", Access.at(1), "failures", Access.at(0)])
     end
   end
 

--- a/test/tribunal/reporter_test.exs
+++ b/test/tribunal/reporter_test.exs
@@ -1,7 +1,7 @@
 defmodule Tribunal.ReporterTest do
   use ExUnit.Case, async: true
 
-  alias Tribunal.Reporter.{Console, GitHub, JSON, JUnit}
+  alias Tribunal.Reporter.{Console, GitHub, HTML, JSON, JUnit, Text}
 
   @sample_results %{
     summary: %{
@@ -93,6 +93,18 @@ defmodule Tribunal.ReporterTest do
       refute output =~ "PASSED"
     end
 
+    test "shows FAILED for an ungated operational error" do
+      results =
+        @sample_results
+        |> put_in([:summary, :gate_status], :error)
+        |> put_in([:summary, :threshold_passed], nil)
+
+      output = Console.format(results)
+
+      assert output =~ "FAILED"
+      refute output =~ "COMPLETED (no gate)"
+    end
+
     test "aligns metric bars across rows" do
       results = %{
         @sample_results
@@ -114,6 +126,18 @@ defmodule Tribunal.ReporterTest do
   end
 
   describe "Text.format/1" do
+    test "shows FAILED for an ungated operational error" do
+      results =
+        @sample_results
+        |> put_in([:summary, :gate_status], :error)
+        |> put_in([:summary, :threshold_passed], nil)
+
+      output = Text.format(results)
+
+      assert output =~ "FAILED"
+      refute output =~ "COMPLETED (no gate)"
+    end
+
     test "aligns metric bars across rows" do
       alias Tribunal.Reporter.Text
 
@@ -133,6 +157,20 @@ defmodule Tribunal.ReporterTest do
 
       assert Enum.uniq(lengths) |> length() == 1,
              "bar rows have different lengths: #{inspect(bar_parts)}"
+    end
+  end
+
+  describe "HTML.format/1" do
+    test "shows FAILED for an ungated operational error" do
+      results =
+        @sample_results
+        |> put_in([:summary, :gate_status], :error)
+        |> put_in([:summary, :threshold_passed], nil)
+
+      output = HTML.format(results)
+
+      assert output =~ ">FAILED<"
+      refute output =~ "COMPLETED (no gate)"
     end
   end
 

--- a/test/tribunal/test_case_test.exs
+++ b/test/tribunal/test_case_test.exs
@@ -36,6 +36,16 @@ defmodule Tribunal.TestCaseTest do
 
       assert tc.context == ["Doc 1", "Doc 2"]
     end
+
+    test "ignores unknown external keys without creating atoms" do
+      key = "unknown_#{System.unique_integer([:positive])}"
+      refute existing_atom?(key)
+
+      tc = TestCase.new(%{"input" => "Hello", key => "ignored"})
+
+      assert tc.input == "Hello"
+      refute existing_atom?(key)
+    end
   end
 
   describe "with_output/2" do
@@ -63,5 +73,12 @@ defmodule Tribunal.TestCaseTest do
 
       assert tc.metadata == %{latency_ms: 150, tokens: 50}
     end
+  end
+
+  defp existing_atom?(value) do
+    _atom = String.to_existing_atom(value)
+    true
+  rescue
+    ArgumentError -> false
   end
 end


### PR DESCRIPTION
Pulls single-case classification into Tribunal.Evaluator and routes both the Mix runner and dataset-backed ExUnit through it. Their orchestration stays separate: ExUnit providers still receive the input value, while the Mix task keeps passing the full Tribunal.TestCase.

The adversarial pass closes the false-green edges this exposed. Missing outputs, provider failures, task exits, timeouts, assertion errors, duplicate assertions, malformed datasets, invalid assertion options, and unknown external names now fail closed without leaking atoms or crashing the run. Ordinary quality failures stay report-only unless a gate is configured, while operational errors exit nonzero even without a gate.

Mix JSON output is now schema version 2. Report-only runs use a nullable threshold_passed field plus an explicit gate_status, and the batch summary includes an errors count. Consumers that assumed threshold_passed was always boolean will need to account for that.

Verified with 340 passing tests and 20 intentionally excluded LLM tests, a clean Credo run, a fresh-VM assertion resolution check, and a real missing-provider CLI run that exited 1 with the expected error fields.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shares single-case evaluation between the Mix runner and dataset-backed ExUnit through a new `Tribunal.Evaluator`. Both runners now fail closed on missing outputs, provider failures, task exits, timeouts, assertion errors, duplicate assertions, malformed datasets, invalid assertion options, and unknown external names.

**Behavior changes**
- Report-only runs exit 0 on quality failures; operational errors exit nonzero even without a configured gate.
- Invalid dataset cases and assertion options are rejected early instead of silently producing false positives.
- Repeated assertion results are preserved, with failures and errors taking precedence over passes in summaries.
- Unknown assertion types and external keys are resolved without creating new atoms.

**JSON output**
- Mix JSON output is now schema version 2.
- `threshold_passed` is `null` when no gate is configured; `gate_status` and `errors` are added to the summary.
- Consumers that assumed `threshold_passed` was always boolean need to update for the new nullable field.

<sup>Written for commit dc3cb331b02c045417716edfd25a9fb6cd5b14df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/tribunal/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

