### PR TITLE
refactor!: Remove redundant text assertion macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Failed Cases
 
 `use Tribunal.ExUnit` imports two evaluation macros and the direct assertion macros below. A direct assertion grades an output you already computed. `tribunal_assert` calls your application for every sample, while `tribunal_dataset` creates one ExUnit test for every dataset row.
 
-Use native ExUnit for substring, equality, regex, prefix, suffix, and length checks:
+Use native ExUnit for ordinary text and JSON checks:
 
 ```elixir
 assert output =~ "30 days"
@@ -194,6 +194,11 @@ assert String.starts_with?(output, "Hello")
 assert String.ends_with?(output, ".")
 assert String.length(output) >= 20
 assert String.length(output) <= 500
+assert String.contains?(output, alternatives)
+assert Enum.all?(required, &String.contains?(output, &1))
+refute String.contains?(output, forbidden)
+assert {:ok, _} = JSON.decode(output)
+assert length(String.split(output, ~r/\s+/, trim: true)) <= 100
 ```
 
 Tribunal provides named dataset assertions for these checks because JSON and YAML cannot contain ExUnit expressions. For URL and email validation, use your application's validation rules or `:regex` for a specific format check.
@@ -247,29 +252,23 @@ tribunal_dataset "test/evals/safety.yaml",
 
 `provider:` is required and must be a `{Module, :function}` pair. Tribunal invokes it as `module.function(test_case.input)`, and it follows the same return contract as `tribunal_assert`. `defaults:`, `repeat:`, and `pass_rule:` work the same way as above. `timeout:` sets the native ExUnit timeout for every generated test. Each dataset row needs `input` and a nonempty `expected` collection.
 
-### Deterministic assertion macros
+### Deterministic assertions
 
-These macros are immediate and need no optional dependency.
-
-| Macro | Passes when | Dataset assertion |
-|---|---|---|
-| `refute_contains(output, value_or_values)` | None of the supplied substrings occur | `not_contains` |
-| `assert_contains_any(output, values)` | At least one supplied substring occurs | `contains_any` |
-| `assert_contains_all(output, values)` | Every supplied substring occurs | `contains_all` |
-| `assert_json(output)` | The complete output decodes as JSON | `is_json` |
-| `assert_word_count(output, opts)` | The whitespace-separated word count satisfies `min:` and/or `max:` | `word_count` |
-| `assert_levenshtein(output, target, opts)` | Edit distance is within `max_distance:`, which defaults to `3` | `levenshtein` |
+`assert_levenshtein(output, target, opts)` checks whether edit distance is within `max_distance:`, which defaults to `3`. It requires no optional dependency. Its dataset assertion is `levenshtein`.
 
 These deterministic assertions are dataset-only:
 
 - `contains` checks one substring and requires a string `value:`. Use `contains_all` with `values:` for every substring in a list, or `contains_any` for alternatives.
+- `not_contains` rejects any supplied substring, using `value:` for one or `values:` for a list.
+- `is_json` checks whether the complete output decodes as JSON.
+- `word_count` checks whitespace-separated word count against `min:` and/or `max:`.
 - `equals` is the dataset equivalent of `assert output == expected` and accepts `value:`.
 - `regex` matches a regular expression supplied as `pattern:` or `value:`.
 - `starts_with` and `ends_with` check a prefix or suffix supplied as `value:`.
 - `min_length` and `max_length` check grapheme length against `min:` or `max:`.
 - `latency_ms` compares `actual:` with `max:`, whose default is `5000` milliseconds.
 
-For example:
+These names configure the underlying checks in datasets and `tribunal_assert`. They remain available even when a direct ExUnit macro is unnecessary. For example:
 
 ```yaml
 expected:

--- a/guides/exunit-integration.md
+++ b/guides/exunit-integration.md
@@ -143,7 +143,7 @@ Direct macros grade an already-computed output once. They do not repeat applicat
 assert response =~ "receipt"
 assert response == expected_response
 assert response =~ ~r/\b30 days\b/
-assert_json response
+assert {:ok, _} = JSON.decode(response)
 assert_faithful response, context: context, threshold: 0.85
 assert_relevant response, query: question
 refute_pii response, query: question

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -121,7 +121,7 @@ defmodule MyApp.RAGTest do
     response = MyApp.RAG.query("What's the return policy?")
 
     assert response =~ "30 days"
-    refute_contains response, "no returns"
+    refute String.contains?(response, "no returns")
   end
 end
 ```

--- a/lib/tribunal/ex_unit.ex
+++ b/lib/tribunal/ex_unit.ex
@@ -284,60 +284,6 @@ defmodule Tribunal.ExUnit.Assertions do
     "#{icon} #{type}#{score_str}#{verdict_str}: #{details[:reason]}"
   end
 
-  @doc "Assert output does not contain substring(s)"
-  defmacro refute_contains(output, value_or_opts) do
-    quote do
-      output = unquote(output)
-      opts = unquote(normalize_opts(value_or_opts))
-
-      case Deterministic.evaluate(:not_contains, output, opts) do
-        {:pass, _} -> :ok
-        {:fail, details} -> flunk(details[:reason])
-        {:error, reason} -> flunk(reason)
-      end
-    end
-  end
-
-  @doc "Assert output contains at least one of the values"
-  defmacro assert_contains_any(output, values) do
-    quote do
-      output = unquote(output)
-      opts = [values: unquote(values)]
-
-      case Deterministic.evaluate(:contains_any, output, opts) do
-        {:pass, _} -> :ok
-        {:fail, details} -> flunk(details[:reason])
-        {:error, reason} -> flunk(reason)
-      end
-    end
-  end
-
-  @doc "Assert output contains all values"
-  defmacro assert_contains_all(output, values) do
-    quote do
-      output = unquote(output)
-      opts = [values: unquote(values)]
-
-      case Deterministic.evaluate(:contains_all, output, opts) do
-        {:pass, _} -> :ok
-        {:fail, details} -> flunk(details[:reason])
-        {:error, reason} -> flunk(reason)
-      end
-    end
-  end
-
-  @doc "Assert output is valid JSON"
-  defmacro assert_json(output) do
-    quote do
-      output = unquote(output)
-
-      case Deterministic.evaluate(:is_json, output, []) do
-        {:pass, _} -> :ok
-        {:fail, details} -> flunk(details[:reason])
-      end
-    end
-  end
-
   @doc """
   Assert output appears to be a refusal.
 
@@ -361,19 +307,6 @@ defmodule Tribunal.ExUnit.Assertions do
       Tribunal.ExUnit.Assertions.print_verbose(:refusal, result, opts)
 
       case result do
-        {:pass, _} -> :ok
-        {:fail, details} -> flunk(details[:reason])
-      end
-    end
-  end
-
-  @doc "Assert output word count within range"
-  defmacro assert_word_count(output, opts) do
-    quote do
-      output = unquote(output)
-      opts = unquote(opts)
-
-      case Deterministic.evaluate(:word_count, output, opts) do
         {:pass, _} -> :ok
         {:fail, details} -> flunk(details[:reason])
       end
@@ -834,8 +767,4 @@ defmodule Tribunal.ExUnit.Assertions do
       end
     end
   end
-
-  defp normalize_opts(value) when is_binary(value), do: [value: value]
-  defp normalize_opts(values) when is_list(values), do: [values: values]
-  defp normalize_opts(opts), do: opts
 end

--- a/test/tribunal/ex_unit_test.exs
+++ b/test/tribunal/ex_unit_test.exs
@@ -9,6 +9,11 @@ defmodule Tribunal.ExUnitTest do
   end
 
   test "does not export removed assertions" do
+    refute macro_exported?(Tribunal.ExUnit.Assertions, :refute_contains, 2)
+    refute macro_exported?(Tribunal.ExUnit.Assertions, :assert_contains_any, 2)
+    refute macro_exported?(Tribunal.ExUnit.Assertions, :assert_contains_all, 2)
+    refute macro_exported?(Tribunal.ExUnit.Assertions, :assert_json, 1)
+    refute macro_exported?(Tribunal.ExUnit.Assertions, :assert_word_count, 2)
     refute macro_exported?(Tribunal.ExUnit.Assertions, :refute_hallucination, 2)
     refute macro_exported?(Tribunal.ExUnit.Assertions, :refute_hallucinated, 2)
     refute macro_exported?(Tribunal.ExUnit.Assertions, :refute_toxic, 1)
@@ -162,81 +167,6 @@ defmodule Tribunal.ExUnitTest do
         )
 
       assert result.input == %{"query" => "returned"}
-    end
-  end
-
-  describe "refute_contains/2" do
-    test "passes when substring not found" do
-      refute_contains("Hello world", "foo")
-    end
-
-    test "fails when substring found" do
-      assert_raise ExUnit.AssertionError, fn ->
-        refute_contains("Hello world", "world")
-      end
-    end
-
-    test "reports invalid configuration as an assertion failure" do
-      error =
-        assert_raise ExUnit.AssertionError, fn ->
-          refute_contains("Hello world", [])
-        end
-
-      assert Exception.message(error) =~ "not_contains requires :value or :values"
-    end
-  end
-
-  describe "assert_contains_any/2" do
-    test "passes when at least one found" do
-      assert_contains_any("Hello world", ["foo", "world", "bar"])
-    end
-
-    test "fails when none found" do
-      assert_raise ExUnit.AssertionError, fn ->
-        assert_contains_any("Hello world", ["foo", "bar"])
-      end
-    end
-
-    test "reports invalid configuration as an assertion failure" do
-      error =
-        assert_raise ExUnit.AssertionError, fn ->
-          assert_contains_any("Hello world", [])
-        end
-
-      assert Exception.message(error) =~ "contains_any requires :value or :values"
-    end
-  end
-
-  describe "assert_contains_all/2" do
-    test "passes when all found" do
-      assert_contains_all("Hello world", ["Hello", "world"])
-    end
-
-    test "fails when some missing" do
-      assert_raise ExUnit.AssertionError, fn ->
-        assert_contains_all("Hello world", ["Hello", "foo"])
-      end
-    end
-
-    test "reports invalid configuration as an assertion failure" do
-      error =
-        assert_raise ExUnit.AssertionError, fn ->
-          assert_contains_all("Hello world", [])
-        end
-
-      assert Exception.message(error) =~ "contains_all requires :value or :values"
-    end
-  end
-
-  describe "assert_json/1" do
-    test "passes with valid JSON" do
-      assert_json(~s({"name": "test"}))
-    end
-
-    test "fails with invalid JSON" do
-      assert_raise ExUnit.AssertionError, fn ->
-        assert_json("not json")
-      end
     end
   end
 
@@ -395,24 +325,6 @@ defmodule Tribunal.ExUnitTest do
         refute_pii("John Smith's SSN is 123-45-6789 and his email is john@example.com",
           model: "zai:glm-4.5-flash"
         )
-      end
-    end
-  end
-
-  describe "assert_word_count/2" do
-    test "passes when within range" do
-      assert_word_count("one two three", min: 2, max: 5)
-    end
-
-    test "fails when below minimum" do
-      assert_raise ExUnit.AssertionError, fn ->
-        assert_word_count("one", min: 2)
-      end
-    end
-
-    test "fails when above maximum" do
-      assert_raise ExUnit.AssertionError, fn ->
-        assert_word_count("one two three four", max: 2)
       end
     end
   end


### PR DESCRIPTION
Remove five convenience macros that duplicate ordinary ExUnit expressions: `assert_contains_all`, `assert_contains_any`, `refute_contains`, `assert_json`, and `assert_word_count`. Update the README and guides with their native Elixir equivalents and remove the unused option-normalization helper.

This is a breaking change for direct macro callers. The underlying `contains_all`, `contains_any`, `not_contains`, `is_json`, and `word_count` assertions remain available in datasets and `tribunal_assert`.

Verified locally: 381 tests passed, 16 live LLM tests excluded, docs built successfully, and the diff passed whitespace checks.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes five convenience macros that duplicated native ExUnit expressions: `assert_contains_all`, `assert_contains_any`, `refute_contains`, `assert_json`, and `assert_word_count`. The dataset assertions and `tribunal_assert` keep these checks, but direct macro callers must now use Elixir's built-ins like `String.contains?`, `JSON.decode`, and `String.split`.

**Migration**
- Replace direct macro calls with the native equivalents shown in the README and guides.
- The unused option-normalization helper is removed.

<sup>Written for commit bd9803bfc6c2e2dbd31d02802d7afc94cf751466. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/georgeguimaraes/tribunal/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

